### PR TITLE
Fix issue with null service PathName 

### DIFF
--- a/Ensconce/Program.cs
+++ b/Ensconce/Program.cs
@@ -356,6 +356,7 @@ namespace Ensconce
 
             return managementObjectCollection
                 .OfType<ManagementObject>()
+                .Where(svc => svc.GetPropertyValue("PathName") != null)
                 .Where(svc => svc.GetPropertyValue("PathName").ToString().Contains(directory))
                 .Select(svc => new ServiceDetails
                 {


### PR DESCRIPTION
can cause ensconce to fail when trying to identify installed services
