### PR TITLE
SetAppPoolIdentity improvements

### DIFF
--- a/createiis6app.ps1
+++ b/createiis6app.ps1
@@ -68,9 +68,24 @@ function CreateAppPool ([string]$name)
 function SetAppPoolIdentity([string]$name, [string]$user, [string]$password)
 {
 	$appPool = gwmi -namespace "root\MicrosoftIISv2" -class "IISApplicationPoolSetting" -filter "Name like '%$name%'"
-	$appPool.WAMUserName = $user
-	$appPool.WAMUserPass = $password
-	$appPool.AppPoolIdentityType = 3
+	
+	# LocalSystem = 0
+	# LocalService = 1
+	# NetworkService = 2
+	# SpecificUser = 3
+	# ApplicationPoolIdentity = 4
+	$identityType = 3
+	if($user -And $user.ToLower() -eq "networkservice")
+	{
+		$identityType = 2
+	}
+	else 
+	{
+		$appPool.WAMUserName = $user
+		$appPool.WAMUserPass = $password
+	}
+	
+	$appPool.AppPoolIdentityType = $identityType
 	$appPool.Put()
 	
 	AddUserToGroup $user "IIS_WPG"

--- a/createiis7app.ps1
+++ b/createiis7app.ps1
@@ -112,12 +112,27 @@ function SetManagedPipelineModeClassic ([string]$name)
 	Set-ItemProperty IIS:\AppPools\$name managedPipelineMode 1
 }
 
+
 function SetAppPoolIdentity([string]$name, [string]$user, [string]$password)
 {
 	$appPool = Get-Item "IIS:\AppPools\$name"
-	$appPool.processModel.username = $user
-	$appPool.processModel.password = $password
-	$appPool.processModel.identityType = 3
+	
+	# LocalSystem = 0
+	# LocalService = 1
+	# NetworkService = 2
+	# SpecificUser = 3
+	# ApplicationPoolIdentity = 4
+	$identityType = 3
+	if($user -And $user.ToLower() -eq "networkservice")
+	{
+		$identityType = 2
+	}
+	else 
+	{
+		$appPool.processModel.username = $user
+		$appPool.processModel.password = $password
+	}
+	$appPool.processModel.identityType = $identityType
 	$appPool | set-item
 }
 


### PR DESCRIPTION
Expand powershell helpers to allow setting an app pool to network service (which uses a different app pool identity type. Works for IIS6 and 7
