### PR TITLE
CreateDesktopShortcut

### DIFF
--- a/deployHelp.ps1
+++ b/deployHelp.ps1
@@ -48,3 +48,11 @@ function EnsurePath([string]$name)
 function is64bit() {
   return ( (Get-WmiObject Win32_OperatingSystem).OSArchitecture -eq "64-bit")
 }
+
+function CreateDesktopShortcut($exePath, $shortcutName)
+{
+	$WshShell = New-Object -comObject WScript.Shell
+	$Shortcut = $WshShell.CreateShortcut((Join-Path $wshShell.SpecialFolders.Item("AllUsersDesktop") "$shortcutName.lnk"))
+	$Shortcut.TargetPath = $exePath
+	$Shortcut.Save()
+}


### PR DESCRIPTION
deployHelp function to create a shortcut for a given file on the All Users desktop.

Is this ok in its genericity? (Made up word, I know)
