### PR TITLE
Better retry handling

### DIFF
--- a/Ensconce.sln
+++ b/Ensconce.sln
@@ -1,6 +1,6 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ensconce", "Ensconce\Ensconce.csproj", "{0B5FD6CF-76AE-4599-9661-4489B62D2851}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "15below.Deployment.Update", "15below.Deployment.Update\15below.Deployment.Update.csproj", "{A59B1375-DC78-47D2-8930-746CD88863AF}"


### PR DESCRIPTION
Handling the following:

2014-06-16 16:15:36 INFO   [Deploy Script]   +00:01.90 - Deleting from C:\MyApplication
2014-06-16 16:15:36 INFO   [Deploy Script]   +00:02.02 - Copying from ..\Content\Service to C:\MyApplication
2014-06-16 16:15:36 INFO   [Deploy Script]   Something went wrong, but we're going to try again. ;(
2014-06-16 16:15:36 INFO   [Deploy Script]   Access to the path 'C:\MyApplication\MyApp.dll' is denied.
2014-06-16 16:15:36 INFO   [Deploy Script]   Something went wrong, but we're going to try again. ;(
2014-06-16 16:15:36 INFO   [Deploy Script]   Could not find a part of the path 'C:\MyApplication\MyApp.dll'.
2014-06-16 16:15:36 INFO   [Deploy Script]   Something went wrong, but we're going to try again. ;(
2014-06-16 16:15:36 INFO   [Deploy Script]   Could not find a part of the path 'C:\MyApplication\MyApp.dll'.

The directory hadn't quite deleted, so the code to re-create didn't fire.
The 1st error is because it's deleting
The other 2 are because the directory now doesn't exist
