### PR TITLE
Add a new function to set the maxRequestEntityAllowed property under asp...

### DIFF
--- a/createiis6app.ps1
+++ b/createiis6app.ps1
@@ -343,10 +343,15 @@ function EnableParentPaths ([string] $websiteName)
 
 function Enable32BitApps ([string] $appPoolName)
 {
-	"The Enable32BirApps function does nothing in IIS6" | Write-Host
+	"The Enable32BitApps function does nothing in IIS6" | Write-Host
 }
 
 function DefaultApplicationPoolGroup ()
 {
 	"IIS_WPG"
+}
+
+function SetMaxRequestEntityAllowed([string] $websiteName, [int] $maxRequestEntityAllowedValue)
+{
+	"The SetMaxRequestEntityAllowed function does nothing in IIS6" | Write-Host
 }

--- a/createiis7app.ps1
+++ b/createiis7app.ps1
@@ -356,3 +356,8 @@ function EnableBasicAuthentication([string] $websiteName)
 {
 	Set-WebConfigurationProperty -filter "/system.webServer/security/authentication/basicAuthentication" -name enabled -value true -PSPath "IIS:\" -location $websiteName
 }
+
+function SetMaxRequestEntityAllowed([string] $websiteName, [int] $maxRequestEntityAllowedValue)
+{
+	Set-WebConfigurationProperty -Filter "//asp/limits" -name maxRequestEntityAllowed -PSPath "IIS:\" -value $maxRequestEntityAllowedValue -location $websiteName
+}


### PR DESCRIPTION
.../limits within a web-configuration section.

Useful when you want to increase the limit due to specific sites displaying more than the standard 200K limit.
