### PR TITLE
RS - Correct dataSourceConnectionString being split on the value's own '='

### DIFF
--- a/15below.Deployment.ReportingServices/MsReportingServices.cs
+++ b/15below.Deployment.ReportingServices/MsReportingServices.cs
@@ -266,7 +266,7 @@ namespace FifteenBelow.Deployment.ReportingServices
                 Password = dataSourcePassWord
             };
 
-            Log("Creating data source {0}", dataSourceName);
+            Log("Creating data source {0} with value: {1}", dataSourceName, dataSourceConnectionString);
             rs.CreateDataSource(dataSourceName, string.Format("/{0}/{1}", parentFolder, subFolder), true, definition, null);
             Log("Created data source {0}", dataSourceName);
         }

--- a/Ensconce/Program.cs
+++ b/Ensconce/Program.cs
@@ -319,7 +319,7 @@ namespace Ensconce
                                 FifteenBelow.Deployment.ReportingServices.DeployHelp.ExampleUsage
                                 , s =>
                                     {
-                                        var reportingServiceVariables = s.Split('=');
+                                        var reportingServiceVariables = s.Split(separator: new [] { '=' }, count: 2);
                                         ReportingServiceVariables.Add(reportingServiceVariables[0], reportingServiceVariables[1]);
                                     }
                                 }


### PR DESCRIPTION
Without this, the connection string passed to SSRS just contains 'Data Source'
