### PR TITLE
Ensure that the last character on a directory is a "\" so when installing to "C:\MyApp" services under "C:\MyAppHelpers" are not found with the contains.

### DIFF
--- a/Ensconce/Program.cs
+++ b/Ensconce/Program.cs
@@ -458,6 +458,8 @@ namespace Ensconce
 
         private static void StopProcessesInDirectory(string directory)
         {
+            if (!directory.EndsWith(@"\")) directory = directory + @"\";
+
             Log("Stopping processes in directory: {0}", directory);
             var wmiQueryString = "SELECT ProcessId, ExecutablePath, CommandLine FROM Win32_Process";
 


### PR DESCRIPTION
Another function with the same issue.
