### PR TITLE
Correct handling of adding roles to users

### DIFF
--- a/15below.Deployment.ReportingServices/MsReportingServices.cs
+++ b/15below.Deployment.ReportingServices/MsReportingServices.cs
@@ -71,9 +71,18 @@ namespace FifteenBelow.Deployment.ReportingServices
 
                 Policy[] existingPolicies = rs.GetPolicies(itemPath, out inheritParent);
 
-                policy = existingPolicies.FirstOrDefault(p => p != null &&
-                    p.GroupUserName.ToUpperInvariant() == reportingUserToAddRoleFor.ToUpperInvariant()
-                );
+                if (reportingUserToAddRoleFor.Contains("\\"))
+                {
+                    policy = existingPolicies.FirstOrDefault(p => p != null &&
+                        p.GroupUserName.ToUpperInvariant() == reportingUserToAddRoleFor.ToUpperInvariant()
+                    );
+                }
+                else
+                {
+                    policy = existingPolicies.FirstOrDefault(p => p != null &&
+                        p.GroupUserName.ToUpperInvariant().Split('\\')[1] == reportingUserToAddRoleFor.ToUpperInvariant()
+                    );
+                }
 
                 if (policy == null)
                 {


### PR DESCRIPTION
This means reporting users can handle the machine name not being present when adding, but user installed has a machine name present.