### PR TITLE
Report User & Roundhouse Fixes

### DIFF
--- a/15below.Deployment.Database/Database.cs
+++ b/15below.Deployment.Database/Database.cs
@@ -83,6 +83,7 @@ namespace FifteenBelow.Deployment
                 .Set(x => x.WarnOnOneTimeScriptChanges = WarnOnOneTimeScriptChanges)
                 .Set(x => x.DisableTokenReplacement = true)
                 .Set(x => x.Drop = dropDatabase)
+                .Set(x => x.DisableOutput = true)
                 .SetCustomLogging(logger);
 
             if (databaseRestoreOptions != null)

--- a/15below.Deployment.ReportingServices/MsReportingServices.cs
+++ b/15below.Deployment.ReportingServices/MsReportingServices.cs
@@ -71,9 +71,18 @@ namespace FifteenBelow.Deployment.ReportingServices
 
                 Policy[] existingPolicies = rs.GetPolicies(itemPath, out inheritParent);
 
-                policy = existingPolicies.FirstOrDefault(p => p != null &&
-                    p.GroupUserName.ToUpperInvariant() == reportingUserToAddRoleFor.ToUpperInvariant()
-                );
+                if (reportingUserToAddRoleFor.Contains("\\"))
+                {
+                    policy = existingPolicies.FirstOrDefault(p => p != null &&
+                        p.GroupUserName.ToUpperInvariant() == reportingUserToAddRoleFor.ToUpperInvariant()
+                    );
+                }
+                else
+                {
+                    policy = existingPolicies.FirstOrDefault(p => p != null &&
+                        p.GroupUserName.ToUpperInvariant().Split('\\')[1] == reportingUserToAddRoleFor.ToUpperInvariant()
+                    );
+                }
 
                 if (policy == null)
                 {


### PR DESCRIPTION
Fixes to correctly handle when the reporting user does not have a domain.
Pass "DisableOutput=true" to roundhouse to prevent flattening the scripts run