### PR TITLE
Update logic for pulling octopus variables into environment variables

### DIFF
--- a/deployHelp.ps1
+++ b/deployHelp.ps1
@@ -4,7 +4,7 @@ if (Test-Path variable:\OctopusParameters)
 {
     foreach($kp in $OctopusParameters.GetEnumerator())
     {
-        if (!($kp -like '*Octopus.Step*'))
+        if (!($kp -like '*Octopus.Step*') -and !($kp -like '*Octopus.Action*') -and !($kp -like '*Octopus.Only*'))
         {
             Set-Content ("env:\" + $kp.Key.replace("[","-").replace("]","")) ($kp.Value) -Force
         }


### PR DESCRIPTION
Take into account the octopus variable name change from "Step" to "Action"
Also adding "Octopus.Only" which means you can call a variable "Octopus.Only.MyReallyLongContent" and this will not be added to an environment variable