### PR TITLE
Improve Error Handling

### DIFF
--- a/src/15below.Deployment.Update.Tests/TagDictionaryTestFiles/webservice-structure.xml
+++ b/src/15below.Deployment.Update.Tests/TagDictionaryTestFiles/webservice-structure.xml
@@ -5,6 +5,7 @@
     <Property name="ClientDomain">{{ ClientCode }}.{{ Environment }}.example.com</Property>
     <Property name="QueueAppServer">ToBeOverriddenAsEnv</Property>
     <Property name="DbEncoded">Overridden!</Property>
+    <Property name="BlankValue"></Property>
     <Property name="DbUser">
       ThisWouldBeAUsername
     </Property>

--- a/src/15below.Deployment.Update.Tests/TagDictionaryTests.cs
+++ b/src/15below.Deployment.Update.Tests/TagDictionaryTests.cs
@@ -275,6 +275,30 @@ namespace FifteenBelow.Deployment.Update.Tests
             var sut = new TagDictionary("ident", new Dictionary<TagSource, string> { { TagSource.Environment, "" }, { TagSource.XmlData, XmlData } });
             Assert.AreEqual(value, sut[friendlyKey]);
         }
+        
+        [Test]
+        public void UseAnInvalidProperty_Throws()
+        {
+            var sut = new TagDictionary("ident", new Dictionary<TagSource, string> { { TagSource.XmlData, XmlData } });
+            var error = Assert.Throws<ArgumentException>(() => "{{ NotARealProperty }}".RenderTemplate(sut));
+            Assert.AreEqual("Tag substitution failed on template string:\n{{ NotARealProperty }}\n\nAttempted rendering was:\n[ERROR OCCURRED HERE]", error.Message);
+        }
+
+        [Test]
+        public void ForLoopAccessGlobalPropertyFromInstance_Throws()
+        {
+            var sut = new TagDictionary("ident", new Dictionary<TagSource, string> { { TagSource.XmlData, XmlData } });
+            var error = Assert.Throws<ArgumentException>(() => "{% for instance in GDS %}{{ instance.DbUser }}{% endfor %}".RenderTemplate(sut));
+            Assert.AreEqual("Tag substitution failed on template string:\n{% for instance in GDS %}{{ instance.DbUser }}{% endfor %}\n\nAttempted rendering was:\n[ERROR OCCURRED HERE][ERROR OCCURRED HERE]", error.Message);
+        }
+
+        [Test]
+        public void ForLoopAccessGlobalPropertyFromInstanceInIf_Throws()
+        {
+            var sut = new TagDictionary("ident", new Dictionary<TagSource, string> { { TagSource.XmlData, XmlData } });
+            var error = Assert.Throws<ArgumentException>(() => "{% for instance in GDS %}{% if instance.DbUser == \"true\" %}TextHere{% endif %}{% endfor %}".RenderTemplate(sut));
+            Assert.AreEqual("Tag substitution failed in rule processing on template string:\n{% for instance in GDS %}{% if instance.DbUser == \"true\" %}TextHere{% endif %}{% endfor %}", error.Message);
+        }
 
         [Test]
         public void ForLoopWorks()

--- a/src/15below.Deployment.Update.Tests/TagDictionaryTests.cs
+++ b/src/15below.Deployment.Update.Tests/TagDictionaryTests.cs
@@ -297,7 +297,23 @@ namespace FifteenBelow.Deployment.Update.Tests
         {
             var sut = new TagDictionary("ident", new Dictionary<TagSource, string> { { TagSource.XmlData, XmlData } });
             var error = Assert.Throws<ArgumentException>(() => "{% for instance in GDS %}{% if instance.DbUser == \"true\" %}TextHere{% endif %}{% endfor %}".RenderTemplate(sut));
-            Assert.AreEqual("Tag substitution failed in rule processing on template string:\n{% for instance in GDS %}{% if instance.DbUser == \"true\" %}TextHere{% endif %}{% endfor %}", error.Message);
+            Assert.AreEqual("Tag substitution errored on template string:\n{% for instance in GDS %}{% if instance.DbUser == \"true\" %}TextHere{% endif %}{% endfor %}", error.Message);
+        }
+
+        [Test]
+        public void ForLoopAccessGlobalPropertyFromInstanceInIfEqual_Throws()
+        {
+            var sut = new TagDictionary("ident", new Dictionary<TagSource, string> { { TagSource.XmlData, XmlData } });
+            var error = Assert.Throws<ArgumentException>(() => "{% for instance in GDS %}{% ifequal instance.DbUser \"true\" %}TextHere{% endifequal %}{% endfor %}".RenderTemplate(sut));
+            Assert.AreEqual("Tag substitution errored on template string:\n{% for instance in GDS %}{% ifequal instance.DbUser \"true\" %}TextHere{% endifequal %}{% endfor %}", error.Message);
+        }
+
+        [Test]
+        public void ForLoopAccessGlobalPropertyFromInstanceInIfNotEqual_Throws()
+        {
+            var sut = new TagDictionary("ident", new Dictionary<TagSource, string> { { TagSource.XmlData, XmlData } });
+            var error = Assert.Throws<ArgumentException>(() => "{% for instance in GDS %}{% ifnotequal instance.DbUser \"true\" %}TextHere{% endifnotequal %}{% endfor %}".RenderTemplate(sut));
+            Assert.AreEqual("Tag substitution errored on template string:\n{% for instance in GDS %}{% ifnotequal instance.DbUser \"true\" %}TextHere{% endifnotequal %}{% endfor %}", error.Message);
         }
 
         [Test]

--- a/src/15below.Deployment.Update.Tests/TagDictionaryTests.cs
+++ b/src/15below.Deployment.Update.Tests/TagDictionaryTests.cs
@@ -366,6 +366,27 @@ namespace FifteenBelow.Deployment.Update.Tests
         }
 
         [Test]
+        public void WhenCollectionEmpty_emptyistrue()
+        {
+            var sut = new TagDictionary("ident", new Dictionary<TagSource, string> { { TagSource.XmlData, XmlData } });
+            Assert.AreEqual("empty", "{% if NotPresent|empty %}empty{% else %}not empty{% endif %}".RenderTemplate(sut));
+        }
+
+        [Test]
+        public void WhenBlankValue_isEmpty()
+        {
+            var sut = new TagDictionary("ident", new Dictionary<TagSource, string> { { TagSource.XmlData, XmlData } });
+            Assert.AreEqual("empty", "{% if BlankValue|empty %}empty{% else %}not empty{% endif %}".RenderTemplate(sut));
+        }
+
+        [Test]
+        public void WhenNotBlnk_NotEmpty()
+        {
+            var sut = new TagDictionary("ident", new Dictionary<TagSource, string> { { TagSource.XmlData, XmlData } });
+            Assert.AreEqual("not empty", "{% if DbEncoded|empty %}empty{% else %}not empty{% endif %}".RenderTemplate(sut));
+        }
+        
+        [Test]
         public void UpdateDREnvironment_WithNotDRMachine()
         {
             Environment.SetEnvironmentVariable("Environment", "DR-LOC");

--- a/src/15below.Deployment.Update/NDjangoExpansions/DefaultFilter.cs
+++ b/src/15below.Deployment.Update/NDjangoExpansions/DefaultFilter.cs
@@ -5,13 +5,6 @@ namespace FifteenBelow.Deployment.Update.NDjangoExpansions
     [Name("default")]
     public class DefaultFilter : IFilter
     {
-        private readonly string templateStringIfInvalid;
-
-        public DefaultFilter(string templateStringIfInvalid)
-        {
-            this.templateStringIfInvalid = templateStringIfInvalid;
-        }
-
         public object Perform(object value)
         {
             throw new System.NotImplementedException();
@@ -19,7 +12,7 @@ namespace FifteenBelow.Deployment.Update.NDjangoExpansions
 
         public object PerformWithParam(object value, object parameter)
         {
-            return value.ToString() == templateStringIfInvalid ? parameter : value;
+            return value is NDjangoWrapper.ErrorTemplate ? parameter : value;
         }
 
         public object DefaultValue

--- a/src/15below.Deployment.Update/NDjangoExpansions/EmptyFilter.cs
+++ b/src/15below.Deployment.Update/NDjangoExpansions/EmptyFilter.cs
@@ -5,16 +5,9 @@ namespace FifteenBelow.Deployment.Update.NDjangoExpansions
     [Name("empty")]
     public class EmptyFilter : ISimpleFilter
     {
-        private readonly string templateStringIfInvalid;
-
-        public EmptyFilter(string templateStringIfInvalid)
-        {
-            this.templateStringIfInvalid = templateStringIfInvalid;
-        }
-
         public object Perform(object value)
         {
-            return string.IsNullOrWhiteSpace(value.ToString()) || value.ToString() == templateStringIfInvalid;
+            return value is NDjangoWrapper.ErrorTemplate || string.IsNullOrWhiteSpace(value.ToString());
         }
     }
 }

--- a/src/15below.Deployment.Update/NDjangoExpansions/ExistsFilter.cs
+++ b/src/15below.Deployment.Update/NDjangoExpansions/ExistsFilter.cs
@@ -5,16 +5,9 @@ namespace FifteenBelow.Deployment.Update.NDjangoExpansions
     [Name("exists")]
     public class ExistsFilter : ISimpleFilter
     {
-        private readonly string templateStringIfInvalid;
-
-        public ExistsFilter(string templateStringIfInvalid)
-        {
-            this.templateStringIfInvalid = templateStringIfInvalid;
-        }
-
         public object Perform(object value)
         {
-            return value.ToString() != templateStringIfInvalid;
+            return !(value is NDjangoWrapper.ErrorTemplate);
         }
     }
 }

--- a/src/15below.Deployment.Update/NDjangoWrapper.cs
+++ b/src/15below.Deployment.Update/NDjangoWrapper.cs
@@ -11,7 +11,6 @@ namespace FifteenBelow.Deployment.Update
     {
         private const string ErrorGuid = "{668B7536-C32B-4D86-B065-70C143EB4AD9}";
         private const string ErrorText = "[ERROR OCCURRED HERE]";
-        private const string StringProvider = "string://";
 
         private static readonly Lazy<ITemplateManager> TemplateManager = new Lazy<ITemplateManager>(() => GetTemplateManager(false));
         private static readonly Lazy<ITemplateManager> XmlTemplateManager = new Lazy<ITemplateManager>(() => GetTemplateManager(true));
@@ -41,7 +40,7 @@ namespace FifteenBelow.Deployment.Update
 
         private static string Render(string template, IDictionary<string, object> values, ITemplateManager templateManager)
         {
-            var replacementValue = templateManager.RenderTemplate(StringProvider + template, values).ReadToEnd();
+            var replacementValue = templateManager.RenderTemplate(template, values).ReadToEnd();
 
             if (replacementValue.Contains(ErrorGuid))
             {
@@ -56,12 +55,8 @@ namespace FifteenBelow.Deployment.Update
         {
             public TextReader GetTemplate(string path)
             {
-                if (path.StartsWith(StringProvider))
-                {
-                    var mem = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(path.Substring(StringProvider.Length)));
-                    return new StreamReader(mem);
-                }
-                return new StreamReader(path);
+                var mem = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(path));
+                return new StreamReader(mem);
             }
 
             public bool IsUpdated(string path, DateTime timestamp)

--- a/src/15below.Deployment.Update/NDjangoWrapper.cs
+++ b/src/15below.Deployment.Update/NDjangoWrapper.cs
@@ -42,25 +42,26 @@ namespace FifteenBelow.Deployment.Update
         {
             lock (Error)
             {
-                Error.Invoked = false;
                 string replacementValue;
 
                 try
                 {
+                    Error.Invoked = false;
                     replacementValue = templateManager.RenderTemplate(template, values).ReadToEnd();
                 }
-                catch (ArgumentException e)
+                catch (Exception)
                 {
-                    if (e.Message == "Object must be of type String.")
-                    {
-                        throw new ArgumentException(string.Format("Tag substitution failed in rule processing on template string:\n{0}", template));
-                    }
-
-                    throw;
+                    replacementValue = string.Empty;
+                    Error.Invoked = true;
                 }
 
                 if (Error.Invoked)
                 {
+                    if (string.IsNullOrWhiteSpace(replacementValue) || !replacementValue.Contains(Error.ToString()))
+                    {
+                        throw new ArgumentException(string.Format("Tag substitution errored on template string:\n{0}", template));
+                    }
+
                     var attemptedRender = replacementValue.Replace(Error.ToString(), "[ERROR OCCURRED HERE]");
                     throw new ArgumentException(string.Format("Tag substitution failed on template string:\n{0}\n\nAttempted rendering was:\n{1}", template, attemptedRender));
                 }
@@ -91,6 +92,18 @@ namespace FifteenBelow.Deployment.Update
             {
                 Invoked = true;
                 return "{RandomText-668B7536-C32B-4D86-B065-70C143EB4AD9}";
+            }
+
+            public override bool Equals(object obj)
+            {
+                Invoked = true;
+                return false;
+            }
+
+            public override int GetHashCode()
+            {
+                Invoked = true;
+                return -1;
             }
         }
     }


### PR DESCRIPTION
When errors occur in rendering (in particular rules) throw exception stating rendering has failed.
This is the same as the behaviour when rendering tags.
However, when rendering tags we can state where the error occurred.
When the error is in the rules, this is not possible, so the template is output and not where the error occurred.
This at least gives a hint as to where you can look.