### PR TITLE
Change to make ensconce not evaluate {% templatetag openvariable %} when…

### DIFF
--- a/src/15below.Deployment.Update.Tests/TagDictionaryTestFiles/structure.xml
+++ b/src/15below.Deployment.Update.Tests/TagDictionaryTestFiles/structure.xml
@@ -24,6 +24,7 @@
           SYS
         </Property>
         <Property name="avalue">idvalue</Property>
+        <Property name="adate">datevalue {% templatetag openvariable %}dd-MM-yy{% templatetag closevariable %}</Property>
       </Properties>
     </PropertyGroup>
   </PropertyGroups>

--- a/src/15below.Deployment.Update.Tests/TagDictionaryTestFiles/webservice-structure.xml
+++ b/src/15below.Deployment.Update.Tests/TagDictionaryTestFiles/webservice-structure.xml
@@ -23,6 +23,7 @@
           SYS
         </Property>
         <Property name="avalue">idvalue</Property>
+        <Property name="adate">datevalue {% templatetag openvariable %}dd-MM-yy{% templatetag closevariable %}</Property>
       </Properties>
     </PropertyGroup>
     <PropertyGroup identity="myId2">
@@ -32,6 +33,7 @@
           SYS2
         </Property>
         <Property name="avalue">idvalue</Property>
+        <Property name="adate">datevalue {% templatetag openvariable %}dd-MM-yy{% templatetag closevariable %}</Property>
       </Properties>
     </PropertyGroup>
   </PropertyGroups>

--- a/src/15below.Deployment.Update.Tests/TagDictionaryTests.cs
+++ b/src/15below.Deployment.Update.Tests/TagDictionaryTests.cs
@@ -50,7 +50,9 @@ namespace FifteenBelow.Deployment.Update.Tests
         private const string XMLFilename = "structure.xml";
         private const string QueAppServer = "QueueAppServer";
         private const string Avalue = "avalue";
+        private const string Adate = "adate";
         private const string Idvalue = "idvalue";
+        private const string Datevalue = "datevalue {% templatetag openvariable %}dd-MM-yy{% templatetag closevariable %}";
 
         private readonly Lazy<string> xml = new Lazy<string>(() => new StreamReader(File.OpenRead(@"webservice-structure.xml")).ReadToEnd());
 
@@ -149,6 +151,13 @@ namespace FifteenBelow.Deployment.Update.Tests
         {
             var loader = new TagDictionary("myId", new Dictionary<TagSource, string> { { TagSource.XmlData, XmlData }, { TagSource.XmlFileName, "structure.xml" } });
             Assert.AreEqual(Idvalue, loader[Avalue]);
+        }
+
+        [Test]
+        public void OpenVariableValueDoesntgetReplacedOnRead()
+        {
+            var loader = new TagDictionary("myId", new Dictionary<TagSource, string> { { TagSource.XmlData, XmlData }, { TagSource.XmlFileName, "structure.xml" } });
+            Assert.AreEqual(Datevalue, loader[Adate]);
         }
 
         private static string GetDbLoginValue(TagDictionary dic, string db, string value)

--- a/src/15below.Deployment.Update/TagDictionary.cs
+++ b/src/15below.Deployment.Update/TagDictionary.cs
@@ -256,7 +256,7 @@ namespace FifteenBelow.Deployment.Update
                                             .Replace("tagClientCode", "{{ ClientCode }}")
                                             .Replace("tagEnvironment", "{{ Environment }}");
 
-            return djangoStyleValue.Contains("{") ? djangoStyleValue.RenderTemplate(this) : baseValue;
+            return djangoStyleValue.Contains("{{") ? djangoStyleValue.RenderTemplate(this) : baseValue;
         }
     }
 }


### PR DESCRIPTION
… it initially builds the tag dictionary. If it evaluates it twice then it throws an error.

Deploying package:    E:\Octopus\Files\LXA.DeployConfiguration.5.51.0-LXREBRAND1-2942.nupkg-900b121e-d503-45ab-843d-65f21fd7dd7e
April 18th 2017 16:40:26Error Something went wrong. :(
April 18th 2017 16:40:26Error One or more errors occurred.
April 18th 2017 16:40:26Error   at Ensconce.Retry.Do[T](Func`1 action, TimeSpan retryInterval, Int32 retryCount) in E:\ba1\50bd7bae7051d4da\src\Ensconce\Retry.cs:line 41
April 18th 2017 16:40:26Error   at Ensconce.TextRendering.<>c.<.cctor>b__7_0() in E:\ba1\50bd7bae7051d4da\src\Ensconce\TextRendering.cs:line 10
April 18th 2017 16:40:26Error   at System.Lazy`1.CreateValue()
April 18th 2017 16:40:26Error   at System.Lazy`1.LazyInitValue()
April 18th 2017 16:40:26Error   at System.Lazy`1.get_Value()
April 18th 2017 16:40:26Error   at Ensconce.Program.MainLogic(String[] args) in E:\ba1\50bd7bae7051d4da\src\Ensconce\Program.cs:line 35
April 18th 2017 16:40:26Error   at Ensconce.Program.Main(String[] args) in E:\ba1\50bd7bae7051d4da\src\Ensconce\Program.cs:line 13
April 18th 2017 16:40:26Info Ensconce failure
April 18th 2017 16:40:26Info Something went wrong, but we're going to try again...
April 18th 2017 16:40:26Info Tag substitution failed on template string:
April 18th 2017 16:40:26Info NOTI PFEM <RECIPIENT> <UTC_TIME format=colon>:00Z/<UTC_DATE format={{dd-MM-yy}}>
April 18th 2017 16:40:26Info Attempted rendering was:
April 18th 2017 16:40:26Info NOTI PFEM <RECIPIENT> <UTC_TIME format=colon>:00Z/<UTC_DATE format=[ERROR OCCURRED HERE]>
April 18th 2017 16:40:26Info Something went wrong, but we're going to try again...
April 18th 2017 16:40:26Info Tag substitution failed on template string:
April 18th 2017 16:40:26Info NOTI PFEM <RECIPIENT> <UTC_TIME format=colon>:00Z/<UTC_DATE format={{dd-MM-yy}}>
April 18th 2017 16:40:26Info Attempted rendering was:
April 18th 2017 16:40:26Info NOTI PFEM <RECIPIENT> <UTC_TIME format=colon>:00Z/<UTC_DATE format=[ERROR OCCURRED HERE]>
April 18th 2017 16:40:26Info Something went wrong, but we're going to try again...
April 18th 2017 16:40:26Info Tag substitution failed on template string:
April 18th 2017 16:40:26Info NOTI PFEM <RECIPIENT> <UTC_TIME format=colon>:00Z/<UTC_DATE format={{dd-MM-yy}}>
April 18th 2017 16:40:26Info Attempted rendering was:
April 18th 2017 16:40:26Info NOTI PFEM <RECIPIENT> <UTC_TIME format=colon>:00Z/<UTC_DATE format=[ERROR OCCURRED HERE]>