### PR TITLE
Added RequireClientCertificate function to iis helper scripts to allo…

### DIFF
--- a/src/Scripts/createiis6app.ps1
+++ b/src/Scripts/createiis6app.ps1
@@ -355,3 +355,8 @@ function SetMaxRequestEntityAllowed([string] $websiteName, [int] $maxRequestEnti
 {
 	"The SetMaxRequestEntityAllowed function does nothing in IIS6" | Write-Host
 }
+
+function RequireClientCertificate([string] $websiteName)
+{
+	throw [System.NotImplementedException] "Only implemented for IIS7 Apps"
+}

--- a/src/Scripts/createiis7app.ps1
+++ b/src/Scripts/createiis7app.ps1
@@ -367,3 +367,9 @@ function SetMaxRequestEntityAllowed([string] $websiteName, [int] $maxRequestEnti
 {
 	Set-WebConfigurationProperty -Filter "//asp/limits" -name maxRequestEntityAllowed -PSPath "IIS:\" -value $maxRequestEntityAllowedValue -location $websiteName
 }
+
+function RequireClientCertificate([string] $websiteName)
+{
+	"Setting SSL Require Client Certs for $websiteName" | Write-Host
+	Set-WebConfiguration -Location "$webSiteName" -filter 'system.webserver/security/access' -Value "Ssl, SslRequireCert"
+}


### PR DESCRIPTION
…w deployment to set Require SSL and Require client certificates for IIS sites - function added and implemented in IIS7 script. Added to IIS6 script but throws not implemented exception