### PR TITLE
Property Group Label Enhancements

### DIFF
--- a/src/15below.Deployment.ReportingServices/Properties/AssemblyInfo.cs
+++ b/src/15below.Deployment.ReportingServices/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.2.0")]
-[assembly: AssemblyVersion("1.0.2.0")]
-[assembly: AssemblyFileVersion("1.0.2.0")]
+// [assembly: AssemblyVersion("1.0.3.0")]
+[assembly: AssemblyVersion("1.0.3.0")]
+[assembly: AssemblyFileVersion("1.0.3.0")]
 [assembly: AssemblyInformationalVersion("1.0.0-feature-Ma-local")]

--- a/src/15below.Deployment.Update.Tests/Properties/AssemblyInfo.cs
+++ b/src/15below.Deployment.Update.Tests/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.2.0")]
-[assembly: AssemblyVersion("1.0.2.0")]
-[assembly: AssemblyFileVersion("1.0.2.0")]
+// [assembly: AssemblyVersion("1.0.3.0")]
+[assembly: AssemblyVersion("1.0.3.0")]
+[assembly: AssemblyFileVersion("1.0.3.0")]
 [assembly: AssemblyInformationalVersion("1.0.0-feature-Ma-local")]

--- a/src/15below.Deployment.Update.Tests/TagDictionaryTestFiles/webservice-structure.xml
+++ b/src/15below.Deployment.Update.Tests/TagDictionaryTestFiles/webservice-structure.xml
@@ -47,6 +47,10 @@
         <Property name="Value">321CBA</Property>
       </Properties>
     </PropertyGroup>
+    <PropertyGroup identity="0">
+      <Label>Label3</Label>
+      <Property name="Value">999</Property>
+    </PropertyGroup>
     <PropertyGroup label="FlatGroup" identity="0">
       <Property name="Value">FlatGroup-0</Property>
     </PropertyGroup>

--- a/src/15below.Deployment.Update.Tests/TagDictionaryTestFiles/webservice-structure.xml
+++ b/src/15below.Deployment.Update.Tests/TagDictionaryTestFiles/webservice-structure.xml
@@ -51,6 +51,15 @@
       <Label>Label3</Label>
       <Property name="Value">999</Property>
     </PropertyGroup>
+    <PropertyGroup identity="0">
+      <Labels>
+        <Label>LabelGrouped1</Label>
+        <Label>LabelGrouped2</Label>
+      </Labels>
+      <Properties>
+        <Property name="Value">888</Property>
+      </Properties>
+    </PropertyGroup>
     <PropertyGroup label="FlatGroup" identity="0">
       <Property name="Value">FlatGroup-0</Property>
     </PropertyGroup>

--- a/src/15below.Deployment.Update.Tests/TagDictionaryTestFiles/webservice-structure.xml
+++ b/src/15below.Deployment.Update.Tests/TagDictionaryTestFiles/webservice-structure.xml
@@ -47,6 +47,12 @@
         <Property name="Value">321CBA</Property>
       </Properties>
     </PropertyGroup>
+    <PropertyGroup label="FlatGroup" identity="0">
+      <Property name="Value">FlatGroup-0</Property>
+    </PropertyGroup>
+    <PropertyGroup label="FlatGroup" identity="1">
+      <Property name="Value">FlatGroup-1</Property>
+    </PropertyGroup>
   </PropertyGroups>
   <DbLogins>
     <DbLogin>

--- a/src/15below.Deployment.Update.Tests/TagDictionaryTestFiles/webservice-structure.xml
+++ b/src/15below.Deployment.Update.Tests/TagDictionaryTestFiles/webservice-structure.xml
@@ -34,6 +34,19 @@
         <Property name="avalue">idvalue</Property>
       </Properties>
     </PropertyGroup>
+    <PropertyGroup identity="0">
+      <Label>Label1</Label>
+      <Label>Label2</Label>
+      <Properties>
+        <Property name="Value">ABC123</Property>
+      </Properties>
+    </PropertyGroup>
+    <PropertyGroup identity="1">
+      <Label>Label1</Label>
+      <Properties>
+        <Property name="Value">321CBA</Property>
+      </Properties>
+    </PropertyGroup>
   </PropertyGroups>
   <DbLogins>
     <DbLogin>

--- a/src/15below.Deployment.Update.Tests/TagDictionaryTests.cs
+++ b/src/15below.Deployment.Update.Tests/TagDictionaryTests.cs
@@ -458,5 +458,12 @@ namespace FifteenBelow.Deployment.Update.Tests
             Assert.AreEqual("FlatGroup-0", "{{ FlatGroup.0.Value }}".RenderTemplate(sut));
             Assert.AreEqual("FlatGroup-1", "{{ FlatGroup.1.Value }}".RenderTemplate(sut));
         }
+
+        [Test]
+        public void LabelNodeWithoutProperties()
+        {
+            var sut = new TagDictionary("ident", new Dictionary<TagSource, string> { { TagSource.XmlData, XmlData } });
+            Assert.AreEqual("999", "{{ Label3.0.Value }}".RenderTemplate(sut));
+        }
     }
 }

--- a/src/15below.Deployment.Update.Tests/TagDictionaryTests.cs
+++ b/src/15below.Deployment.Update.Tests/TagDictionaryTests.cs
@@ -465,5 +465,13 @@ namespace FifteenBelow.Deployment.Update.Tests
             var sut = new TagDictionary("ident", new Dictionary<TagSource, string> { { TagSource.XmlData, XmlData } });
             Assert.AreEqual("999", "{{ Label3.0.Value }}".RenderTemplate(sut));
         }
+
+        [Test]
+        public void DualLabeledGroupWithContainerNodeWorks()
+        {
+            var sut = new TagDictionary("ident", new Dictionary<TagSource, string> { { TagSource.XmlData, XmlData } });
+            Assert.AreEqual("888", "{{ LabelGrouped1.0.Value }}".RenderTemplate(sut));
+            Assert.AreEqual("888", "{{ LabelGrouped2.0.Value }}".RenderTemplate(sut));
+        }
     }
 }

--- a/src/15below.Deployment.Update.Tests/TagDictionaryTests.cs
+++ b/src/15below.Deployment.Update.Tests/TagDictionaryTests.cs
@@ -433,5 +433,15 @@ namespace FifteenBelow.Deployment.Update.Tests
             var sut = new TagDictionary("ident", new Dictionary<TagSource, string> { { TagSource.XmlData, XmlData } });
             Assert.AreEqual(xml.Value.RenderTemplate(sut), "{% include \"webservice-structure.xml\" %}".RenderTemplate(sut));
         }
+
+        [Test]
+        public void DualLabeledGroupWorks()
+        {
+            var sut = new TagDictionary("ident", new Dictionary<TagSource, string> { { TagSource.XmlData, XmlData } });
+            Assert.AreEqual("ABC123", "{{ Label1.0.Value }}".RenderTemplate(sut));
+            Assert.AreEqual("ABC123", "{{ Label2.0.Value }}".RenderTemplate(sut));
+            Assert.AreEqual("321CBA", "{{ Label1.1.Value }}".RenderTemplate(sut));
+            Assert.Throws<ArgumentException>(() => "{{ Label2.1.Value }}".RenderTemplate(sut));
+        }
     }
 }

--- a/src/15below.Deployment.Update.Tests/TagDictionaryTests.cs
+++ b/src/15below.Deployment.Update.Tests/TagDictionaryTests.cs
@@ -1,9 +1,9 @@
-﻿using System;
+﻿using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using NUnit.Framework;
 
 namespace FifteenBelow.Deployment.Update.Tests
 {
@@ -233,6 +233,13 @@ namespace FifteenBelow.Deployment.Update.Tests
         }
 
         [Test]
+        public void LoadFlatLabelledGroups()
+        {
+            var sut = new TagDictionary("ident", XmlData);
+            Assert.IsTrue(sut.ContainsKey("FlatGroup"));
+        }
+
+        [Test]
         public void LoadLabelledGroupsValuesAndNormalIdentityValuesAvailable()
         {
             var sut = new TagDictionary("ident", new Dictionary<TagSource, string> { { TagSource.XmlFileName, "structure.xml" } });
@@ -275,7 +282,7 @@ namespace FifteenBelow.Deployment.Update.Tests
             var sut = new TagDictionary("ident", new Dictionary<TagSource, string> { { TagSource.Environment, "" }, { TagSource.XmlData, XmlData } });
             Assert.AreEqual(value, sut[friendlyKey]);
         }
-        
+
         [Test]
         public void UseAnInvalidProperty_Throws()
         {
@@ -442,6 +449,14 @@ namespace FifteenBelow.Deployment.Update.Tests
             Assert.AreEqual("ABC123", "{{ Label2.0.Value }}".RenderTemplate(sut));
             Assert.AreEqual("321CBA", "{{ Label1.1.Value }}".RenderTemplate(sut));
             Assert.Throws<ArgumentException>(() => "{{ Label2.1.Value }}".RenderTemplate(sut));
+        }
+
+        [Test]
+        public void FlatLabelGroupsHaveValues()
+        {
+            var sut = new TagDictionary("ident", new Dictionary<TagSource, string> { { TagSource.XmlData, XmlData } });
+            Assert.AreEqual("FlatGroup-0", "{{ FlatGroup.0.Value }}".RenderTemplate(sut));
+            Assert.AreEqual("FlatGroup-1", "{{ FlatGroup.1.Value }}".RenderTemplate(sut));
         }
     }
 }

--- a/src/15below.Deployment.Update/15below.Deployment.Update.csproj
+++ b/src/15below.Deployment.Update/15below.Deployment.Update.csproj
@@ -74,6 +74,11 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="FixedStructure.xsd">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/15below.Deployment.Update/FixedStructure.xsd
+++ b/src/15below.Deployment.Update/FixedStructure.xsd
@@ -2,7 +2,7 @@
 <xs:schema xmlns:i="http://www.w3.org/2001/XMLSchema-instance" attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:group name="Property">
     <xs:sequence>
-      <xs:element maxOccurs="unbounded" name="Property">
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="Property">
         <xs:complexType>
           <xs:simpleContent>
             <xs:extension base="xs:string">
@@ -15,7 +15,7 @@
   </xs:group>
   <xs:element name="Structure">
     <xs:complexType>
-      <xs:sequence>
+      <xs:all>
         <xs:element name="ClientCode" type="xs:string" />
         <xs:element name="Environment" type="xs:string" />
         <xs:element name="Properties">
@@ -27,7 +27,7 @@
           <xs:complexType>
             <xs:sequence>
               <xs:choice>
-                <xs:element maxOccurs="unbounded" name="PropertyGroup">
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="PropertyGroup">
                   <xs:complexType>
                     <xs:sequence>
                       <xs:choice>
@@ -60,34 +60,32 @@
         <xs:element name="DbLogins">
           <xs:complexType>
             <xs:sequence>
-              <xs:element maxOccurs="unbounded" name="DbLogin">
+              <xs:element maxOccurs="unbounded" minOccurs="0" name="DbLogin">
                 <xs:complexType>
-                  <xs:sequence>
-                    <xs:choice>
-                      <xs:sequence>
-                        <xs:element name="Key" type="xs:string" />
-                        <xs:element name="Name" type="xs:string" />
-                        <xs:element name="DefaultDb" type="xs:string" />
-                        <xs:element name="Password" type="xs:string" />
-                      </xs:sequence>
-                      <xs:sequence>
-                        <xs:element name="Name" type="xs:string" />
-                        <xs:choice>
-                          <xs:sequence>
-                            <xs:element name="DefaultDb" type="xs:string" />
-                            <xs:element name="Password" type="xs:string" />
-                          </xs:sequence>
-                          <xs:element name="ConnectionString" type="xs:string" />
-                        </xs:choice>
-                      </xs:sequence>
-                    </xs:choice>
-                  </xs:sequence>
+                  <xs:choice>
+                    <xs:sequence>
+                      <xs:element name="Key" type="xs:string" />
+                      <xs:element name="Name" type="xs:string" />
+                      <xs:element name="DefaultDb" type="xs:string" />
+                      <xs:element name="Password" type="xs:string" />
+                    </xs:sequence>
+                    <xs:sequence>
+                      <xs:element name="Name" type="xs:string" />
+                      <xs:choice>
+                        <xs:sequence>
+                          <xs:element name="DefaultDb" type="xs:string" />
+                          <xs:element name="Password" type="xs:string" />
+                        </xs:sequence>
+                        <xs:element name="ConnectionString" type="xs:string" />
+                      </xs:choice>
+                    </xs:sequence>
+                  </xs:choice>
                 </xs:complexType>
               </xs:element>
             </xs:sequence>
           </xs:complexType>
         </xs:element>
-      </xs:sequence>
+      </xs:all>
     </xs:complexType>
   </xs:element>
 </xs:schema>

--- a/src/15below.Deployment.Update/FixedStructure.xsd
+++ b/src/15below.Deployment.Update/FixedStructure.xsd
@@ -1,0 +1,93 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:i="http://www.w3.org/2001/XMLSchema-instance" attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:group name="Property">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" name="Property">
+        <xs:complexType>
+          <xs:simpleContent>
+            <xs:extension base="xs:string">
+              <xs:attribute name="name" type="xs:string" use="required" />
+            </xs:extension>
+          </xs:simpleContent>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:element name="Structure">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="ClientCode" type="xs:string" />
+        <xs:element name="Environment" type="xs:string" />
+        <xs:element name="Properties">
+          <xs:complexType>
+            <xs:group ref="Property"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="PropertyGroups">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:choice>
+                <xs:element maxOccurs="unbounded" name="PropertyGroup">
+                  <xs:complexType>
+                    <xs:sequence>
+                      <xs:choice>
+                        <xs:element name="Labels" minOccurs="0">
+                          <xs:complexType>
+                            <xs:sequence>
+                              <xs:element maxOccurs="unbounded" name="Label" type="xs:string" />
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+                        <xs:element maxOccurs="unbounded" minOccurs="0" name="Label" type="xs:string" />
+                      </xs:choice>
+                      <xs:choice>
+                        <xs:element name="Properties">
+                          <xs:complexType>
+                            <xs:group ref="Property"/>
+                          </xs:complexType>
+                        </xs:element>
+                        <xs:group ref="Property"/>
+                      </xs:choice>
+                    </xs:sequence>
+                    <xs:attribute name="identity" type="xs:string" use="required" />
+                    <xs:attribute name="label" type="xs:string" use="optional" />
+                  </xs:complexType>
+                </xs:element>
+              </xs:choice>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="DbLogins">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element maxOccurs="unbounded" name="DbLogin">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:choice>
+                      <xs:sequence>
+                        <xs:element name="Key" type="xs:string" />
+                        <xs:element name="Name" type="xs:string" />
+                        <xs:element name="DefaultDb" type="xs:string" />
+                        <xs:element name="Password" type="xs:string" />
+                      </xs:sequence>
+                      <xs:sequence>
+                        <xs:element name="Name" type="xs:string" />
+                        <xs:choice>
+                          <xs:sequence>
+                            <xs:element name="DefaultDb" type="xs:string" />
+                            <xs:element name="Password" type="xs:string" />
+                          </xs:sequence>
+                          <xs:element name="ConnectionString" type="xs:string" />
+                        </xs:choice>
+                      </xs:sequence>
+                    </xs:choice>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/src/15below.Deployment.Update/Properties/AssemblyInfo.cs
+++ b/src/15below.Deployment.Update/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.2.0")]
-[assembly: AssemblyVersion("1.0.2.0")]
-[assembly: AssemblyFileVersion("1.0.2.0")]
+// [assembly: AssemblyVersion("1.0.3.0")]
+[assembly: AssemblyVersion("1.0.3.0")]
+[assembly: AssemblyFileVersion("1.0.3.0")]
 [assembly: AssemblyInformationalVersion("1.0.0-feature-Ma-local")]

--- a/src/15below.Deployment.Update/TagDictionary.cs
+++ b/src/15below.Deployment.Update/TagDictionary.cs
@@ -188,7 +188,7 @@ namespace FifteenBelow.Deployment.Update
                     }
 
                     //Support Properties being in Properties node, or at root
-                    foreach (var prop in propertyGroup.XPathSelectElements("Properties/Property").Concat(propertyGroup.XPathSelectElements("Property")))
+                    foreach (var prop in propertyGroup.XPathSelectElements(".//Property"))
                     {
                         var key = prop.Attribute("name").Value;
                         var value = prop.Value.Trim();

--- a/src/15below.Deployment.Update/TagDictionary.cs
+++ b/src/15below.Deployment.Update/TagDictionary.cs
@@ -2,7 +2,10 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Xml;
 using System.Xml.Linq;
+using System.Xml.Schema;
 using System.Xml.XPath;
 
 namespace FifteenBelow.Deployment.Update
@@ -94,11 +97,22 @@ namespace FifteenBelow.Deployment.Update
                 return;
             }
 
+            ValidateStructureFile(doc);
             BasePropertiesFromXml(doc);
             IdentityPropertyGroupsFromXml(identifier, doc);
             GeneralPropertiesFromXml(doc);
             LabelPropertiesFromXml(doc);
             DbLoginPropertiesFromXml(doc);
+        }
+
+        private static void ValidateStructureFile(XDocument doc)
+        {
+            var schemas = new XmlSchemaSet();
+            var assembly = Assembly.GetExecutingAssembly();
+
+            schemas.Add(null, XmlReader.Create(assembly.GetManifestResourceStream("FifteenBelow.Deployment.Update.FixedStructure.xsd")));
+
+            doc.Validate(schemas, (sender, args) => { throw args.Exception; });
         }
 
         private void BasePropertiesFromXml(XDocument doc)

--- a/src/15below.Deployment.Update/TagDictionary.cs
+++ b/src/15below.Deployment.Update/TagDictionary.cs
@@ -197,7 +197,6 @@ namespace FifteenBelow.Deployment.Update
                         labelDic.Add(identity, instanceDic);
                     }
 
-                    //Support Properties being in Properties node, or at root
                     foreach (var prop in propertyGroup.XPathSelectElements(".//Property"))
                     {
                         var key = prop.Attribute("name").Value;

--- a/src/15below.Deployment.Update/TagDictionary.cs
+++ b/src/15below.Deployment.Update/TagDictionary.cs
@@ -145,13 +145,9 @@ namespace FifteenBelow.Deployment.Update
                 {
                     labels.Add(propertyGroup.Attribute("label").Value);
                 }
-                else if (propertyGroup.XPathSelectElements("Label").Any())
+                else if (propertyGroup.XPathSelectElements(".//Label").Any())
                 {
-                    labels.AddRange(propertyGroup.XPathSelectElements("Label").Select(x => x.Value));
-                }
-                else if (propertyGroup.XPathSelectElements("Labels/Label").Any())
-                {
-                    labels.AddRange(propertyGroup.XPathSelectElements("Labels/Label").Select(x => x.Value));
+                    labels.AddRange(propertyGroup.XPathSelectElements(".//Label").Select(x => x.Value));
                 }
                 else
                 {

--- a/src/15below.Deployment.Update/TagDictionary.cs
+++ b/src/15below.Deployment.Update/TagDictionary.cs
@@ -145,9 +145,13 @@ namespace FifteenBelow.Deployment.Update
                 {
                     labels.Add(propertyGroup.Attribute("label").Value);
                 }
-                else if (propertyGroup.Elements().Select(e => e.Name).Contains("Label"))
+                else if (propertyGroup.XPathSelectElements("Label").Any())
                 {
-                    labels.AddRange(propertyGroup.Elements("Label").Select(e => e.Value));
+                    labels.AddRange(propertyGroup.XPathSelectElements("Label").Select(x => x.Value));
+                }
+                else if (propertyGroup.XPathSelectElements("Labels/Label").Any())
+                {
+                    labels.AddRange(propertyGroup.XPathSelectElements("Labels/Label").Select(x => x.Value));
                 }
                 else
                 {

--- a/src/15below.Deployment.Update/UpdateFile.cs
+++ b/src/15below.Deployment.Update/UpdateFile.cs
@@ -85,13 +85,12 @@ namespace FifteenBelow.Deployment.Update
 
             if (fileElement == null) return File.ReadAllText(baseFile);
 
-            string replacementTemplate;
             string baseData = null;
 
             var replacementTemplateElement = fileElement.XPathSelectElement("s:ReplacementTemplate", nsm);
             if (replacementTemplateElement != null)
             {
-                replacementTemplate = replacementTemplateElement.Value.RenderTemplate(tagValues);
+                var replacementTemplate = replacementTemplateElement.Value.RenderTemplate(tagValues);
                 baseData = File.ReadAllText(replacementTemplate).RenderTemplate(tagValues);
             }
 
@@ -113,9 +112,7 @@ namespace FifteenBelow.Deployment.Update
             var schemas = new XmlSchemaSet();
             var assembly = Assembly.GetExecutingAssembly();
 
-            schemas.Add(null,
-                        XmlReader.Create(
-                            assembly.GetManifestResourceStream("FifteenBelow.Deployment.Update.Substitutions.xsd")));
+            schemas.Add(null, XmlReader.Create(assembly.GetManifestResourceStream("FifteenBelow.Deployment.Update.Substitutions.xsd")));
 
             subsXml.Validate(schemas, (sender, args) => { throw args.Exception; });
         }
@@ -146,7 +143,7 @@ namespace FifteenBelow.Deployment.Update
 
                 if (activeNode == null)
                 {
-                    throw new ApplicationException(String.Format("XPath select of {0} returned null", sub.XPath));
+                    throw new ApplicationException(string.Format("XPath select of {0} returned null", sub.XPath));
                 }
 
                 if (sub.HasReplacementContent) ReplaceChildNodes(tagValues, activeNode, sub);

--- a/src/Deploy/ensconce.nuspec
+++ b/src/Deploy/ensconce.nuspec
@@ -2,7 +2,7 @@
 <package>
 	<metadata>
 		<id>Ensconce</id>
-		<version>1.0.2.0</version>
+		<version>1.0.3.0</version>
 		<title>Ensconce</title>
 		<authors>15below Ltd</authors>
 		<owners>15below Ltd</owners>

--- a/src/Ensconce.Database.Tests/Properties/AssemblyInfo.cs
+++ b/src/Ensconce.Database.Tests/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.2.0")]
-[assembly: AssemblyVersion("1.0.2.0")]
-[assembly: AssemblyFileVersion("1.0.2.0")]
+// [assembly: AssemblyVersion("1.0.3.0")]
+[assembly: AssemblyVersion("1.0.3.0")]
+[assembly: AssemblyFileVersion("1.0.3.0")]
 [assembly: AssemblyInformationalVersion("1.0.0-feature-Ma-local")]

--- a/src/Ensconce/Properties/AssemblyInfo.cs
+++ b/src/Ensconce/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.2.0")]
-[assembly: AssemblyVersion("1.0.2.0")]
-[assembly: AssemblyFileVersion("1.0.2.0")]
+// [assembly: AssemblyVersion("1.0.3.0")]
+[assembly: AssemblyVersion("1.0.3.0")]
+[assembly: AssemblyFileVersion("1.0.3.0")]
 [assembly: AssemblyInformationalVersion("1.0.0-feature-Ma-local")]


### PR DESCRIPTION
Features/Changes
- Add missing tests for groups with more than 1 label.
- Add ability to wrap multiple labels in a "Labels" nodes.
- Add ability to specify a single label as a "label" attribute (rather than as a single Label node).
- Allow "Property" nodes to be at the root of the property group as well as inside a "Properties" node as before.
- Add XSD for structure files and validate against it