### PR TITLE
PS1 Loading Messages & Tag Dictionary JSON Export

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,9 +1,9 @@
+framework: auto-detect
 redirects: on
-source https://api.nuget.org/v3/index.json
+source https://nuget.org/api/v2/
 
-// Turn off redirects here to allow test runners to use their own versions
-nuget NUnit 2.6.4 redirects: off
-nuget NUnit.Runners 2.6.4 redirects: off
-nuget RhinoMocks 3.6.0
+nuget NUnit
+nuget RhinoMocks
+nuget Newtonsoft.Json
 
-github 15below/Build.Tools:paket
+github 15below/Build.Tools:master

--- a/paket.lock
+++ b/paket.lock
@@ -1,16 +1,30 @@
 REDIRECTS: ON
+RESTRICTION: == net40
 NUGET
-  remote: https://api.nuget.org/v3/index.json
-    FAKE (4.50.1)
+  remote: https://www.nuget.org/api/v2
+    FAKE (4.63.2)
+    Newtonsoft.Json (10.0.3)
     NuGet.CommandLine (2.8.3)
-    NUnit (2.6.4) - redirects: off
-    NUnit.Runners (2.6.4)
-    OctoPack (3.5)
-    RhinoMocks (3.6)
+    NUnit (3.8.1)
+    NUnit.Console (3.7)
+      NUnit.ConsoleRunner (>= 3.7)
+      NUnit.Extension.NUnitProjectLoader (>= 3.5)
+      NUnit.Extension.NUnitV2Driver (>= 3.6)
+      NUnit.Extension.NUnitV2ResultWriter (>= 3.5)
+      NUnit.Extension.TeamCityEventListener (>= 1.0.2)
+      NUnit.Extension.VSProjectLoader (>= 3.5)
+    NUnit.ConsoleRunner (3.7)
+    NUnit.Extension.NUnitProjectLoader (3.6)
+    NUnit.Extension.NUnitV2Driver (3.7)
+    NUnit.Extension.NUnitV2ResultWriter (3.6)
+    NUnit.Extension.TeamCityEventListener (1.0.2)
+    NUnit.Extension.VSProjectLoader (3.6)
+    OctoPack (3.6.3)
+    RhinoMocks (3.6.1)
 GITHUB
   remote: 15below/Build.Tools
-    FULLPROJECT (3660e7adb3f1729e7b4c5eeb501f28308d9094d1)
+    FULLPROJECT (cec5b14c56caec5571a5c4046e1099eedec7c412)
       Fake
       Nuget.CommandLine (2.8.3)
-      Nunit.Runners
+      NUnit.Console
       OctoPack

--- a/src/15below.Deployment.ReportingServices/Properties/AssemblyInfo.cs
+++ b/src/15below.Deployment.ReportingServices/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.3.0")]
-[assembly: AssemblyVersion("1.0.3.0")]
-[assembly: AssemblyFileVersion("1.0.3.0")]
+// [assembly: AssemblyVersion("1.0.4.0")]
+[assembly: AssemblyVersion("1.0.4.0")]
+[assembly: AssemblyFileVersion("1.0.4.0")]
 [assembly: AssemblyInformationalVersion("1.0.0-feature-Ma-local")]

--- a/src/15below.Deployment.Update.Tests/15below.Deployment.Update.Tests.csproj
+++ b/src/15below.Deployment.Update.Tests/15below.Deployment.Update.Tests.csproj
@@ -221,11 +221,15 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  <ItemGroup>
-    <Reference Include="nunit.framework">
-      <HintPath>..\..\packages\NUnit\lib\nunit.framework.dll</HintPath>
-      <Private>True</Private>
-      <Paket>True</Paket>
-    </Reference>
-  </ItemGroup>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.0'">
+      <ItemGroup>
+        <Reference Include="nunit.framework">
+          <HintPath>..\..\packages\NUnit\lib\net40\nunit.framework.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
 </Project>

--- a/src/15below.Deployment.Update.Tests/Properties/AssemblyInfo.cs
+++ b/src/15below.Deployment.Update.Tests/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.3.0")]
-[assembly: AssemblyVersion("1.0.3.0")]
-[assembly: AssemblyFileVersion("1.0.3.0")]
+// [assembly: AssemblyVersion("1.0.4.0")]
+[assembly: AssemblyVersion("1.0.4.0")]
+[assembly: AssemblyFileVersion("1.0.4.0")]
 [assembly: AssemblyInformationalVersion("1.0.0-feature-Ma-local")]

--- a/src/15below.Deployment.Update.Tests/TagDictionaryTests.cs
+++ b/src/15below.Deployment.Update.Tests/TagDictionaryTests.cs
@@ -20,6 +20,7 @@ namespace FifteenBelow.Deployment.Update.Tests
         [SetUp]
         public void SetUp()
         {
+            Environment.CurrentDirectory = TestContext.CurrentContext.TestDirectory;
             testLock.WaitOne();
             var testEnv = new Dictionary<string, string>
                               {

--- a/src/15below.Deployment.Update.Tests/UpdateFileTests.cs
+++ b/src/15below.Deployment.Update.Tests/UpdateFileTests.cs
@@ -1,17 +1,23 @@
-﻿using System;
+﻿using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
 using System.Xml.Linq;
 using System.Xml.Schema;
 using System.Xml.XPath;
-using NUnit.Framework;
 
 namespace FifteenBelow.Deployment.Update.Tests
 {
     [TestFixture]
     public class UpdateFileTests
     {
+        [SetUp]
+        public void Setup()
+        {
+            Environment.CurrentDirectory = TestContext.CurrentContext.TestDirectory;
+        }
+
         [Test]
         public void SubstituteOldValueWithNewStaticValue()
         {
@@ -39,7 +45,7 @@ namespace FifteenBelow.Deployment.Update.Tests
         public void SubstituteOldValueWithNewTaggedValue()
         {
             var newConfig = XDocument.Parse(UpdateFile.Update(
-                @"TestUpdateFiles\TestSubstitution4.xml", @"TestUpdateFiles\TestConfig1.xml", new Dictionary<string, object> {{"taggedReplacementContent", "newvalue"}}
+                @"TestUpdateFiles\TestSubstitution4.xml", @"TestUpdateFiles\TestConfig1.xml", new Dictionary<string, object> { { "taggedReplacementContent", "newvalue" } }
                 ));
             Assert.AreEqual("newvalue", newConfig.XPathSelectElement("/root/value").Value);
         }
@@ -48,7 +54,7 @@ namespace FifteenBelow.Deployment.Update.Tests
         public void SubstituteOldValueWithNewTaggedXmlValue()
         {
             var newConfig = XDocument.Parse(UpdateFile.Update(
-                @"TestUpdateFiles\TestSubstitution5.xml", @"TestUpdateFiles\TestConfig1.xml", new Dictionary<string, object> {{"taggedReplacementContent", "newvalue"}}
+                @"TestUpdateFiles\TestSubstitution5.xml", @"TestUpdateFiles\TestConfig1.xml", new Dictionary<string, object> { { "taggedReplacementContent", "newvalue" } }
                 ));
             Assert.AreEqual("newvalue", newConfig.XPathSelectElement("/root/value").Descendants().First().Name.LocalName);
         }
@@ -91,7 +97,7 @@ namespace FifteenBelow.Deployment.Update.Tests
                 ));
             Assert.AreEqual("after", newConfig.XPathSelectElement("/root/value").Attribute("myAttr").Value);
         }
-        
+
         [Test]
         public void DoNotRemoveAttributesUnlessSpecified()
         {
@@ -100,7 +106,7 @@ namespace FifteenBelow.Deployment.Update.Tests
                 ));
             Assert.AreEqual("quack", newConfig.XPathSelectElement("/root/value").Attribute("duckAttr").Value);
         }
-        
+
         [Test]
         public void DoNotChangeChildrenUnlessNewValueSpecified()
         {
@@ -141,25 +147,25 @@ namespace FifteenBelow.Deployment.Update.Tests
         public void SubstituteTaggedAttributeValue()
         {
             var newConfig = XDocument.Parse(UpdateFile.Update(
-                @"TestUpdateFiles\TestSubstitution9.xml", @"TestUpdateFiles\TestConfig3.xml", new Dictionary<string, object>{{"newValue", "after"}}
+                @"TestUpdateFiles\TestSubstitution9.xml", @"TestUpdateFiles\TestConfig3.xml", new Dictionary<string, object> { { "newValue", "after" } }
                 ));
             Assert.AreEqual("after", newConfig.XPathSelectElement("/root/value").Attribute("myAttr").Value);
         }
-        
+
         [Test]
         public void AppendAfterWorks()
         {
             var newConfig = XDocument.Parse(UpdateFile.Update(
-                @"TestUpdateFiles\TestSubstitution14.xml", @"TestUpdateFiles\TestConfig1.xml", new Dictionary<string, object>{{"newValue", "after"}}
+                @"TestUpdateFiles\TestSubstitution14.xml", @"TestUpdateFiles\TestConfig1.xml", new Dictionary<string, object> { { "newValue", "after" } }
                 ));
             Assert.IsTrue(newConfig.Root.Descendants().Select(el => el.Name).Contains("NewTag"));
         }
-        
+
         [Test]
         public void AddChildContentWorks()
         {
             var newConfig = XDocument.Parse(UpdateFile.Update(
-                @"TestUpdateFiles\TestSubstitution15.xml", @"TestUpdateFiles\TestConfig1.xml", new Dictionary<string, object>{{"newValue", "after"}}
+                @"TestUpdateFiles\TestSubstitution15.xml", @"TestUpdateFiles\TestConfig1.xml", new Dictionary<string, object> { { "newValue", "after" } }
                 ));
             Assert.AreEqual(1, newConfig.XPathSelectElements("/root/value/NewTag").Count());
         }
@@ -187,7 +193,7 @@ namespace FifteenBelow.Deployment.Update.Tests
                             XDocument.Parse(configs.Where(c => c.Item1 == @"TestUpdateFiles\TestConfig1.xml").Single().Item2).XPathSelectElement
                                 ("/root/value/testing").Value);
         }
-        
+
         [Test]
         public void AppendAfterWorksWithAmpersandInTag()
         {
@@ -204,7 +210,7 @@ namespace FifteenBelow.Deployment.Update.Tests
         public void EmptyChildContentWorks()
         {
             var newConfig = XDocument.Parse(UpdateFile.Update(
-                @"TestUpdateFiles\TestSubstitution16.xml", @"TestUpdateFiles\TestConfig1.xml", new Dictionary<string, object>{{"newValue", "after"}}
+                @"TestUpdateFiles\TestSubstitution16.xml", @"TestUpdateFiles\TestConfig1.xml", new Dictionary<string, object> { { "newValue", "after" } }
                 ));
             Assert.IsTrue(newConfig.XPathSelectElements("/root/value/NewTag").Count() == 0);
         }
@@ -213,17 +219,17 @@ namespace FifteenBelow.Deployment.Update.Tests
         public void MultipleChildContentWorks()
         {
             var newConfig = XDocument.Parse(UpdateFile.Update(
-                @"TestUpdateFiles\TestSubstitution17.xml", @"TestUpdateFiles\TestConfig1.xml", new Dictionary<string, object>{{"newValue", "after"}}
+                @"TestUpdateFiles\TestSubstitution17.xml", @"TestUpdateFiles\TestConfig1.xml", new Dictionary<string, object> { { "newValue", "after" } }
                 ));
             Assert.AreEqual("1", newConfig.XPathSelectElements("/root/value/one").First().Value);
             Assert.AreEqual("2", newConfig.XPathSelectElements("/root/value/two").First().Value);
         }
-        
+
         [Test]
         public void UpdateAllTouchesAllFiles()
         {
             var configs = UpdateFile.UpdateAll(@"TestUpdateFiles\TestSubstitution3.xml",
-                                               new Dictionary<string, object> {{"tagValue", "Tagged!"}});
+                                               new Dictionary<string, object> { { "tagValue", "Tagged!" } });
             var nms = new XmlNamespaceManager(new NameTable());
             nms.AddNamespace("c", "http://madeup.com");
             Assert.AreEqual("newvalue",
@@ -238,7 +244,7 @@ namespace FifteenBelow.Deployment.Update.Tests
         public void UpdateAllKnowsAboutTaggedFiles()
         {
             var configs = UpdateFile.UpdateAll(@"TestUpdateFiles\TestSubstitution13.xml",
-                                               new Dictionary<string, object> {{"FilePath", "TaggedPath"}});
+                                               new Dictionary<string, object> { { "FilePath", "TaggedPath" } });
             Assert.AreEqual("newvalue",
                             XDocument.Parse(configs.Where(c => c.Item1 == @"TestUpdateFiles\TestConfig-TaggedPath.xml").Single().Item2).
                                 XPathSelectElement("/root/value").Value);
@@ -248,7 +254,7 @@ namespace FifteenBelow.Deployment.Update.Tests
         public void TagsOutsideSpecifiedXPathsUnchanged()
         {
             var newConfig = XDocument.Parse(UpdateFile.Update(
-                @"TestUpdateFiles\TestSubstitution9.xml", @"TestUpdateFiles\TestConfig3.xml", new Dictionary<string, object>{{"newValue", "after"}}
+                @"TestUpdateFiles\TestSubstitution9.xml", @"TestUpdateFiles\TestConfig3.xml", new Dictionary<string, object> { { "newValue", "after" } }
                 ));
             Assert.AreEqual("{{ tagged }}", newConfig.XPathSelectElement("/root/myValue").Value);
         }
@@ -257,7 +263,7 @@ namespace FifteenBelow.Deployment.Update.Tests
         public void ReplaceFileWithTemplateWorks()
         {
             var newConfig = XDocument.Parse(UpdateFile.Update(
-                @"TestUpdateFiles\TestSubstitution10.xml", @"TestUpdateFiles\TestConfig2.xml", new Dictionary<string, object>{{"tagged", "after"}}
+                @"TestUpdateFiles\TestSubstitution10.xml", @"TestUpdateFiles\TestConfig2.xml", new Dictionary<string, object> { { "tagged", "after" } }
                 ));
             Assert.AreEqual("after", newConfig.XPathSelectElement("/root/myValue").Value);
         }
@@ -266,7 +272,7 @@ namespace FifteenBelow.Deployment.Update.Tests
         public void NewFileWithTemplateWorks()
         {
             var newConfig = XDocument.Parse(UpdateFile.Update(
-                @"TestUpdateFiles\TestSubstitution11.xml", @"TestUpdateFiles\DoesntExist.xml", new Dictionary<string, object>{{"tagged", "after"}}
+                @"TestUpdateFiles\TestSubstitution11.xml", @"TestUpdateFiles\DoesntExist.xml", new Dictionary<string, object> { { "tagged", "after" } }
                 ));
             Assert.AreEqual("after", newConfig.XPathSelectElement("/root/myValue").Value);
         }
@@ -275,7 +281,7 @@ namespace FifteenBelow.Deployment.Update.Tests
         public void TemplateAndChangesWork()
         {
             var newConfig = XDocument.Parse(UpdateFile.Update(
-                @"TestUpdateFiles\TestSubstitution18.xml", @"TestUpdateFiles\TestConfig2.xml", new Dictionary<string, object>{{"tagged", "after"}}
+                @"TestUpdateFiles\TestSubstitution18.xml", @"TestUpdateFiles\TestConfig2.xml", new Dictionary<string, object> { { "tagged", "after" } }
                 ));
             Assert.AreEqual("after", newConfig.XPathSelectElement("/root/myValue").Value);
             Assert.AreEqual("afterAttr", newConfig.XPathSelectElement("/root/myValue").Attribute("myAttr").Value);
@@ -286,7 +292,7 @@ namespace FifteenBelow.Deployment.Update.Tests
         {
             var newConfig = XDocument.Parse(UpdateFile.Update(
                 @"TestUpdateFiles\TestSubstitution19.xml", @"TestUpdateFiles\TestConfig2.xml",
-                new Dictionary<string, object> {{"tagged", "after"}, {"Environment", "LOC"}}
+                new Dictionary<string, object> { { "tagged", "after" }, { "Environment", "LOC" } }
                                                 ));
             Assert.AreEqual("after", newConfig.XPathSelectElement("/root/myValue-LOC").Value);
             Assert.AreEqual("afterAttr", newConfig.XPathSelectElement("/root/myValue-LOC").Attribute("myAttr").Value);
@@ -297,7 +303,7 @@ namespace FifteenBelow.Deployment.Update.Tests
         {
             Assert.Throws<XmlSchemaValidationException>(() => XDocument.Parse(UpdateFile.Update(
                 @"TestUpdateFiles\TestSubstitution20.xml", @"TestUpdateFiles\TestConfig2.xml",
-                new Dictionary<string, object> {{"tagged", "after"}, {"Environment", "LOC"}}
+                new Dictionary<string, object> { { "tagged", "after" }, { "Environment", "LOC" } }
                                                 )));
         }
 
@@ -306,7 +312,7 @@ namespace FifteenBelow.Deployment.Update.Tests
         {
             var newConfig = UpdateFile.Update(
                 @"TestUpdateFiles\TestSubstitution21.xml", @"TestUpdateFiles\PlainText01.txt",
-                new Dictionary<string, object> {{"tag", "after"}, {"Environment", "LOC"}});
+                new Dictionary<string, object> { { "tag", "after" }, { "Environment", "LOC" } });
             Assert.IsTrue(newConfig.Contains("after"));
         }
 
@@ -315,7 +321,7 @@ namespace FifteenBelow.Deployment.Update.Tests
         {
             var newConfig = UpdateFile.Update(
                 @"TestUpdateFiles\TestSubstitution21.xml", @"TestUpdateFiles\PlainText01.txt",
-                new Dictionary<string, object> {{"tag", "<after>"}, {"Environment", "LOC"}});
+                new Dictionary<string, object> { { "tag", "<after>" }, { "Environment", "LOC" } });
             Assert.IsTrue(newConfig.Contains("<after>"));
         }
 
@@ -324,7 +330,7 @@ namespace FifteenBelow.Deployment.Update.Tests
         {
             var newConfig = UpdateFile.Update(
                 @"TestUpdateFiles\TestSubstitution22.xml", @"TestUpdateFiles\PlainText02.txt",
-                new Dictionary<string, object> {{"tag", "<after>"}, {"Environment", "LOC"}});
+                new Dictionary<string, object> { { "tag", "<after>" }, { "Environment", "LOC" } });
             Assert.AreEqual("Some plain text. With a {{ tag }}.", newConfig);
         }
 
@@ -332,7 +338,7 @@ namespace FifteenBelow.Deployment.Update.Tests
         public void NDjangoFiltersAvailable()
         {
             var newConfig = XDocument.Parse(UpdateFile.Update(
-                @"TestUpdateFiles\TestSubstitution12.xml", @"TestUpdateFiles\TestConfig1.xml", new Dictionary<string, object>{{"newvalue", "AfTer"}}
+                @"TestUpdateFiles\TestSubstitution12.xml", @"TestUpdateFiles\TestConfig1.xml", new Dictionary<string, object> { { "newvalue", "AfTer" } }
                 ));
             Assert.AreEqual("after", newConfig.XPathSelectElement("/root/value").Value);
         }
@@ -342,7 +348,7 @@ namespace FifteenBelow.Deployment.Update.Tests
         {
             var newConfig = UpdateFile.Update(
                 @"TestUpdateFiles\TestSubstitution23.xml", @"TestUpdateFiles\PlainText03.txt",
-                new Dictionary<string, object> {{"tag", "<after>"}, {"Environment", "LOC"}});
+                new Dictionary<string, object> { { "tag", "<after>" }, { "Environment", "LOC" } });
             Assert.AreEqual("Some plain text. With a concat <after></after>.", newConfig);
         }
     }

--- a/src/15below.Deployment.Update/Properties/AssemblyInfo.cs
+++ b/src/15below.Deployment.Update/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.3.0")]
-[assembly: AssemblyVersion("1.0.3.0")]
-[assembly: AssemblyFileVersion("1.0.3.0")]
+// [assembly: AssemblyVersion("1.0.4.0")]
+[assembly: AssemblyVersion("1.0.4.0")]
+[assembly: AssemblyFileVersion("1.0.4.0")]
 [assembly: AssemblyInformationalVersion("1.0.0-feature-Ma-local")]

--- a/src/Deploy/ensconce.nuspec
+++ b/src/Deploy/ensconce.nuspec
@@ -2,7 +2,7 @@
 <package>
 	<metadata>
 		<id>Ensconce</id>
-		<version>1.0.3.0</version>
+		<version>1.0.4.0</version>
 		<title>Ensconce</title>
 		<authors>15below Ltd</authors>
 		<owners>15below Ltd</owners>

--- a/src/Ensconce.Database.Tests/Ensconce.Database.Tests.csproj
+++ b/src/Ensconce.Database.Tests/Ensconce.Database.Tests.csproj
@@ -86,18 +86,26 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  <ItemGroup>
-    <Reference Include="nunit.framework">
-      <HintPath>..\..\packages\NUnit\lib\nunit.framework.dll</HintPath>
-      <Private>True</Private>
-      <Paket>True</Paket>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="Rhino.Mocks">
-      <HintPath>..\..\packages\RhinoMocks\lib\Rhino.Mocks.dll</HintPath>
-      <Private>True</Private>
-      <Paket>True</Paket>
-    </Reference>
-  </ItemGroup>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.0'">
+      <ItemGroup>
+        <Reference Include="nunit.framework">
+          <HintPath>..\..\packages\NUnit\lib\net40\nunit.framework.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.0'">
+      <ItemGroup>
+        <Reference Include="Rhino.Mocks">
+          <HintPath>..\..\packages\RhinoMocks\lib\net\Rhino.Mocks.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
 </Project>

--- a/src/Ensconce.Database.Tests/Properties/AssemblyInfo.cs
+++ b/src/Ensconce.Database.Tests/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.3.0")]
-[assembly: AssemblyVersion("1.0.3.0")]
-[assembly: AssemblyFileVersion("1.0.3.0")]
+// [assembly: AssemblyVersion("1.0.4.0")]
+[assembly: AssemblyVersion("1.0.4.0")]
+[assembly: AssemblyFileVersion("1.0.4.0")]
 [assembly: AssemblyInformationalVersion("1.0.0-feature-Ma-local")]

--- a/src/Ensconce/DictionaryExport.cs
+++ b/src/Ensconce/DictionaryExport.cs
@@ -1,0 +1,27 @@
+﻿using Newtonsoft.Json;
+using System.IO;
+using System.Net;
+
+namespace Ensconce
+{
+    internal static class DictionaryExport
+    {
+        internal static void ExportTagDictionary()
+        {
+            var dictionary = JsonConvert.SerializeObject(TextRendering.TagDictionary, Formatting.Indented);
+
+            if (!string.IsNullOrWhiteSpace(Arguments.DictionarySavePath))
+            {
+                File.WriteAllText(Arguments.DictionarySavePath, dictionary);
+            }
+
+            if (!string.IsNullOrWhiteSpace(Arguments.DictionaryPostUrl))
+            {
+                using (var cli = new WebClient { Headers = { [HttpRequestHeader.ContentType] = "application/json" } })
+                {
+                    cli.UploadString(Arguments.DictionaryPostUrl, dictionary);
+                }
+            }
+        }
+    }
+}

--- a/src/Ensconce/Ensconce.csproj
+++ b/src/Ensconce/Ensconce.csproj
@@ -120,6 +120,7 @@
     <Compile Include="ApplicationInteraction.cs" />
     <Compile Include="Arguments.cs" />
     <Compile Include="DatabaseInteraction.cs" />
+    <Compile Include="DictionaryExport.cs" />
     <Compile Include="FileInteraction.cs" />
     <Compile Include="Logging.cs" />
     <Compile Include="Options.cs" />

--- a/src/Ensconce/Ensconce.csproj
+++ b/src/Ensconce/Ensconce.csproj
@@ -132,6 +132,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="paket.references" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\15below.Deployment.Database\15below.Deployment.Database.csproj">
@@ -155,4 +156,15 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.0'">
+      <ItemGroup>
+        <Reference Include="Newtonsoft.Json">
+          <HintPath>..\..\packages\Newtonsoft.Json\lib\net40\Newtonsoft.Json.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
 </Project>

--- a/src/Ensconce/Program.cs
+++ b/src/Ensconce/Program.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using System.Threading;
 
 namespace Ensconce
@@ -27,6 +26,12 @@ namespace Ensconce
             Arguments.SetUpAndParseOptions(args);
 
             Logging.Log("Arguments parsed");
+
+            if (!string.IsNullOrWhiteSpace(Arguments.DictionarySavePath) || !string.IsNullOrWhiteSpace(Arguments.DictionaryPostUrl))
+            {
+                DictionaryExport.ExportTagDictionary();
+                return;
+            }
 
             if (Arguments.ReadFromStdIn)
             {

--- a/src/Ensconce/Properties/AssemblyInfo.cs
+++ b/src/Ensconce/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.3.0")]
-[assembly: AssemblyVersion("1.0.3.0")]
-[assembly: AssemblyFileVersion("1.0.3.0")]
+// [assembly: AssemblyVersion("1.0.4.0")]
+[assembly: AssemblyVersion("1.0.4.0")]
+[assembly: AssemblyFileVersion("1.0.4.0")]
 [assembly: AssemblyInformationalVersion("1.0.0-feature-Ma-local")]

--- a/src/Ensconce/paket.references
+++ b/src/Ensconce/paket.references
@@ -1,0 +1,1 @@
+Newtonsoft.Json

--- a/src/Scripts/createWebSite.ps1
+++ b/src/Scripts/createWebSite.ps1
@@ -1,3 +1,4 @@
+Write-Host "Ensconce - CreateWebsite Loading"
 $DeployToolsDir = Split-Path ((Get-Variable MyInvocation -Scope 0).Value.MyCommand.Path)
 
 $ErrorActionPreference = 'SilentlyContinue'
@@ -22,3 +23,4 @@ else
 	write-host "Using IIS7"
 	. $DeployToolsDir\createiis7app.ps1
 }
+Write-Host "Ensconce - CreateWebsite Loaded"

--- a/src/Scripts/createWebSite.ps1
+++ b/src/Scripts/createWebSite.ps1
@@ -23,4 +23,5 @@ else
 	write-host "Using IIS7"
 	. $DeployToolsDir\createiis7app.ps1
 }
+
 Write-Host "Ensconce - CreateWebsite Loaded"

--- a/src/Scripts/createiis6app.ps1
+++ b/src/Scripts/createiis6app.ps1
@@ -1,7 +1,6 @@
 Write-Host "Ensconce - CreateIIS6App Loading"
 $frameworkPath = (Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Client").InstallPath 
 set-alias regIIS $frameworkPath\aspnet_regiis.exe
-Write-Host "Ensconce - CreateIIS6App Loaded"
 
 function TestInclude ([string]$name) {
 	(get-host).ui.rawui.foregroundcolor= "Magenta"
@@ -362,3 +361,5 @@ function RequireClientCertificate([string] $websiteName)
 {
 	throw [System.NotImplementedException] "Only implemented for IIS7 Apps"
 }
+
+Write-Host "Ensconce - CreateIIS6App Loaded"

--- a/src/Scripts/createiis6app.ps1
+++ b/src/Scripts/createiis6app.ps1
@@ -1,5 +1,7 @@
+Write-Host "Ensconce - CreateIIS6App Loading"
 $frameworkPath = (Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Client").InstallPath 
 set-alias regIIS $frameworkPath\aspnet_regiis.exe
+Write-Host "Ensconce - CreateIIS6App Loaded"
 
 function TestInclude ([string]$name) {
 	(get-host).ui.rawui.foregroundcolor= "Magenta"

--- a/src/Scripts/createiis7app.ps1
+++ b/src/Scripts/createiis7app.ps1
@@ -50,8 +50,6 @@ if ($LoadAsSnapin) {
 	}
 }
 
-Write-Host "Ensconce - CreateIIS7App Loaded"
-
 function CheckIfAppPoolExists ([string]$name)
 {
 	Test-Path "IIS:\AppPools\$name"
@@ -376,3 +374,5 @@ function RequireClientCertificate([string] $websiteName)
 	"Setting SSL Require Client Certs for $websiteName" | Write-Host
 	Set-WebConfiguration -Location "$webSiteName" -filter 'system.webserver/security/access' -Value "Ssl, SslRequireCert"
 }
+
+Write-Host "Ensconce - CreateIIS7App Loaded"

--- a/src/Scripts/createiis7app.ps1
+++ b/src/Scripts/createiis7app.ps1
@@ -1,3 +1,4 @@
+Write-Host "Ensconce - CreateIIS7App Loading"
 # Resource For Looking Up IIS Powershell Snap In Commands/Functions
 # http://learn.iis.net/page.aspx/447/managing-iis-with-the-iis-powershell-snap-in/
 
@@ -48,6 +49,8 @@ if ($LoadAsSnapin) {
 		exit 1
 	}
 }
+
+Write-Host "Ensconce - CreateIIS7App Loaded"
 
 function CheckIfAppPoolExists ([string]$name)
 {

--- a/src/Scripts/deployHelp.ps1
+++ b/src/Scripts/deployHelp.ps1
@@ -17,8 +17,6 @@ if(!(Test-Path "env:\ConfigOnly"))
     Set-Content "env:\ConfigOnly" $false
 }
 
-Write-Host "Ensconce - DeployHelp Loaded"
-
 function ensconce
 {
     if (@($input).Count -ne 0)
@@ -59,3 +57,5 @@ function CreateDesktopShortcut($exePath, $shortcutName)
 	$Shortcut.TargetPath = $exePath
 	$Shortcut.Save()
 }
+
+Write-Host "Ensconce - DeployHelp Loaded"

--- a/src/Scripts/deployHelp.ps1
+++ b/src/Scripts/deployHelp.ps1
@@ -1,4 +1,5 @@
-﻿$DeployToolsDir = Split-Path ((Get-Variable MyInvocation -Scope 0).Value.MyCommand.Path)
+﻿Write-Host "Ensconce - DeployHelp Loading"
+$DeployToolsDir = Split-Path ((Get-Variable MyInvocation -Scope 0).Value.MyCommand.Path)
 
 if (Test-Path variable:\OctopusParameters)
 {
@@ -15,6 +16,8 @@ if(!(Test-Path "env:\ConfigOnly"))
 {
     Set-Content "env:\ConfigOnly" $false
 }
+
+Write-Host "Ensconce - DeployHelp Loaded"
 
 function ensconce
 {

--- a/src/Scripts/dnsHelper.ps1
+++ b/src/Scripts/dnsHelper.ps1
@@ -1,5 +1,4 @@
 Write-Host "Ensconce - dnsHelper Loading"
-Write-Host "Ensconce - dnsHelper Loaded"
 
 function CheckName ([string]$dnsServer, [string]$domain, [string]$lookupName)
 {                                                                               
@@ -98,3 +97,5 @@ function AddHostsEntry ([string]$Address, [string]$FullyQualifiedName)
 	
 	CheckHostsEntry $Address $FullyQualifiedName
 }
+
+Write-Host "Ensconce - dnsHelper Loaded"

--- a/src/Scripts/dnsHelper.ps1
+++ b/src/Scripts/dnsHelper.ps1
@@ -1,3 +1,6 @@
+Write-Host "Ensconce - dnsHelper Loading"
+Write-Host "Ensconce - dnsHelper Loaded"
+
 function CheckName ([string]$dnsServer, [string]$domain, [string]$lookupName)
 {                                                                               
 	$result = dnscmd $dnsServer /EnumRecords $domain $lookupName

--- a/src/Scripts/userManagement.ps1
+++ b/src/Scripts/userManagement.ps1
@@ -23,8 +23,6 @@ $ADS_UF_DONT_REQUIRE_PREAUTH          = 4194304 # 0x400000
 $ADS_UF_PASSWORD_EXPIRED            = 8388608 # 0x800000
 $ADS_UF_TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION = 16777216 # 0x1000000
 
-Write-Host "Ensconce - UserManagement Loaded"
-
 Function AddUser([string]$name, [string]$password)
 {
 	$computer = [ADSI]"WinNT://$env:computername,computer"
@@ -143,3 +141,5 @@ Function SetServiceAccount([string]$serviceName, [string]$account, [string]$pass
 		"Service $serviceName set to use account $account" | Write-Host
 	}
 }
+
+Write-Host "Ensconce - UserManagement Loaded"

--- a/src/Scripts/userManagement.ps1
+++ b/src/Scripts/userManagement.ps1
@@ -1,3 +1,4 @@
+Write-Host "Ensconce - UserManagement Loading"
 # ADS_USER_FLAG_ENUM Enumeration
 # http://msdn.microsoft.com/en-us/library/aa772300(VS.85).aspx
 $ADS_UF_SCRIPT                 = 1   # 0x1
@@ -21,6 +22,8 @@ $ADS_UF_USE_DES_KEY_ONLY            = 2097152 # 0x200000
 $ADS_UF_DONT_REQUIRE_PREAUTH          = 4194304 # 0x400000
 $ADS_UF_PASSWORD_EXPIRED            = 8388608 # 0x800000
 $ADS_UF_TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION = 16777216 # 0x1000000
+
+Write-Host "Ensconce - UserManagement Loaded"
 
 Function AddUser([string]$name, [string]$password)
 {


### PR DESCRIPTION
Added a Loading/Loaded message to scripts to show what is loading and how long it took.

Added --dictionaryPostUrl argument and --dictionarySavePath which can be used to either save the entire tag dictionary locally, or post that dictionary to another location.

This means Ensconce could now generate config and post it to a configuration store the applications read from as well as updating configuration files.