### PR TITLE
contains / startsWith / endsWith / decrypt support

### DIFF
--- a/src/15below.Deployment.ReportingServices/Properties/AssemblyInfo.cs
+++ b/src/15below.Deployment.ReportingServices/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.4.0")]
-[assembly: AssemblyVersion("1.0.4.0")]
-[assembly: AssemblyFileVersion("1.0.4.0")]
+// [assembly: AssemblyVersion("1.0.5.0")]
+[assembly: AssemblyVersion("1.0.5.0")]
+[assembly: AssemblyFileVersion("1.0.5.0")]
 [assembly: AssemblyInformationalVersion("1.0.0-feature-Ma-local")]

--- a/src/15below.Deployment.Update.Tests/Properties/AssemblyInfo.cs
+++ b/src/15below.Deployment.Update.Tests/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.4.0")]
-[assembly: AssemblyVersion("1.0.4.0")]
-[assembly: AssemblyFileVersion("1.0.4.0")]
+// [assembly: AssemblyVersion("1.0.5.0")]
+[assembly: AssemblyVersion("1.0.5.0")]
+[assembly: AssemblyFileVersion("1.0.5.0")]
 [assembly: AssemblyInformationalVersion("1.0.0-feature-Ma-local")]

--- a/src/15below.Deployment.Update.Tests/TagDictionaryTests.cs
+++ b/src/15below.Deployment.Update.Tests/TagDictionaryTests.cs
@@ -530,12 +530,13 @@ namespace FifteenBelow.Deployment.Update.Tests
             var sut = new TagDictionary("ident", $@"<Structure xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"">
                                                       <Properties>
                                                         <Property name=""Data"">{value}</Property>
+                                                        <Property name=""Certificate"">XX-NON-Certificate</Property>
                                                       </Properties>
                                                   </Structure>");
 
             var expected = "hello";
 
-            Assert.AreEqual(expected.ToString().ToLower(), "{{ Data|decrypt:'XX-NON-Certificate' }}".RenderTemplate(sut));
+            Assert.AreEqual(expected.ToString().ToLower(), "{{ Data|decrypt:Certificate }}".RenderTemplate(sut));
         }
 
         [Test]

--- a/src/15below.Deployment.Update.Tests/TagDictionaryTests.cs
+++ b/src/15below.Deployment.Update.Tests/TagDictionaryTests.cs
@@ -422,9 +422,13 @@ namespace FifteenBelow.Deployment.Update.Tests
         public void Contains(string value, string contains, bool expected)
         {
             var sut = new TagDictionary("ident", $@"<Structure xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"">
+                                                      <ClientCode>XX</ClientCode>
+                                                      <Environment>LOC</Environment>
                                                       <Properties>
                                                         <Property name=""Data"">{value}</Property>
                                                       </Properties>
+                                                      <PropertyGroups />
+                                                      <DbLogins />
                                                   </Structure>");
 
             Assert.AreEqual(expected.ToString().ToLower(), "{% if Data|contains:'#contains#' %}true{% else %}false{% endif %}".Replace("#contains#", contains).RenderTemplate(sut));
@@ -434,9 +438,13 @@ namespace FifteenBelow.Deployment.Update.Tests
         public void Contains_EmptyString_Throws()
         {
             var sut = new TagDictionary("ident", @"<Structure xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"">
+                                                      <ClientCode>XX</ClientCode>
+                                                      <Environment>LOC</Environment>
                                                       <Properties>
                                                         <Property name=""Data"">Value</Property>
                                                       </Properties>
+                                                      <PropertyGroups />
+                                                      <DbLogins />
                                                   </Structure>");
 
             Assert.Throws<ArgumentException>(() => "{% if Data|contains:'' %}true{% else %}false{% endif %}".RenderTemplate(sut));
@@ -446,9 +454,13 @@ namespace FifteenBelow.Deployment.Update.Tests
         public void Contains_WhenPropertyDoesntExist_Throws()
         {
             var sut = new TagDictionary("ident", $@"<Structure xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"">
+                                                      <ClientCode>XX</ClientCode>
+                                                      <Environment>LOC</Environment>
                                                       <Properties>
                                                         <Property name=""Data"">Value</Property>
                                                       </Properties>
+                                                      <PropertyGroups />
+                                                      <DbLogins />
                                                   </Structure>");
 
             Assert.Throws<ArgumentException>(() => "{% if Undata|contains:'al' %}true{% else %}false{% endif %}".RenderTemplate(sut));
@@ -461,8 +473,11 @@ namespace FifteenBelow.Deployment.Update.Tests
         public void Contains_WhenPropertyDoesntExist_Defaulted(string value, string contains, bool expected)
         {
             var sut = new TagDictionary("ident", $@"<Structure xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"">
-                                                      <Properties>
-                                                      </Properties>
+                                                      <ClientCode>XX</ClientCode>
+                                                      <Environment>LOC</Environment>
+                                                      <Properties />
+                                                      <PropertyGroups />
+                                                      <DbLogins />
                                                   </Structure>");
 
             Assert.AreEqual(expected.ToString().ToLower(), "{% if Data|default:'#value#'|contains:'#endsWith#' %}true{% else %}false{% endif %}".Replace("#endsWith#", contains).Replace("#value#", value).RenderTemplate(sut));
@@ -475,9 +490,13 @@ namespace FifteenBelow.Deployment.Update.Tests
         public void StartsWith(string value, string startsWith, bool expected)
         {
             var sut = new TagDictionary("ident", $@"<Structure xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"">
+                                                      <ClientCode>XX</ClientCode>
+                                                      <Environment>LOC</Environment>
                                                       <Properties>
                                                         <Property name=""Data"">{value}</Property>
                                                       </Properties>
+                                                      <PropertyGroups />
+                                                      <DbLogins />
                                                   </Structure>");
 
             Assert.AreEqual(expected.ToString().ToLower(), "{% if Data|startsWith:'#startsWith#' %}true{% else %}false{% endif %}".Replace("#startsWith#", startsWith).RenderTemplate(sut));
@@ -487,9 +506,13 @@ namespace FifteenBelow.Deployment.Update.Tests
         public void StartsWith_EmptyString_Throws()
         {
             var sut = new TagDictionary("ident", @"<Structure xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"">
+                                                      <ClientCode>XX</ClientCode>
+                                                      <Environment>LOC</Environment>
                                                       <Properties>
                                                         <Property name=""Data"">Value</Property>
                                                       </Properties>
+                                                      <PropertyGroups />
+                                                      <DbLogins />
                                                   </Structure>");
 
             Assert.Throws<ArgumentException>(() => "{% if Data|startsWith:'' %}true{% else %}false{% endif %}".RenderTemplate(sut));
@@ -499,9 +522,13 @@ namespace FifteenBelow.Deployment.Update.Tests
         public void StartsWith_WhenPropertyDoesntExist_Throws()
         {
             var sut = new TagDictionary("ident", $@"<Structure xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"">
+                                                      <ClientCode>XX</ClientCode>
+                                                      <Environment>LOC</Environment>
                                                       <Properties>
                                                         <Property name=""Data"">Value</Property>
                                                       </Properties>
+                                                      <PropertyGroups />
+                                                      <DbLogins />
                                                   </Structure>");
 
             Assert.Throws<ArgumentException>(() => "{% if Undata|startsWith:'V' %}true{% else %}false{% endif %}".RenderTemplate(sut));
@@ -514,8 +541,11 @@ namespace FifteenBelow.Deployment.Update.Tests
         public void StartsWith_WhenPropertyDoesntExist_Defaulted(string value, string startsWith, bool expected)
         {
             var sut = new TagDictionary("ident", $@"<Structure xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"">
-                                                      <Properties>
-                                                      </Properties>
+                                                      <ClientCode>XX</ClientCode>
+                                                      <Environment>LOC</Environment>
+                                                      <Properties />
+                                                      <PropertyGroups />
+                                                      <DbLogins />
                                                   </Structure>");
 
             Assert.AreEqual(expected.ToString().ToLower(), "{% if Data|default:'#value#'|startsWith:'#endsWith#' %}true{% else %}false{% endif %}".Replace("#endsWith#", startsWith).Replace("#value#", value).RenderTemplate(sut));
@@ -528,9 +558,13 @@ namespace FifteenBelow.Deployment.Update.Tests
         public void EndsWith(string value, string endsWith, bool expected)
         {
             var sut = new TagDictionary("ident", $@"<Structure xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"">
+                                                      <ClientCode>XX</ClientCode>
+                                                      <Environment>LOC</Environment>
                                                       <Properties>
                                                         <Property name=""Data"">{value}</Property>
                                                       </Properties>
+                                                      <PropertyGroups />
+                                                      <DbLogins />
                                                   </Structure>");
 
             Assert.AreEqual(expected.ToString().ToLower(), "{% if Data|endsWith:'#endsWith#' %}true{% else %}false{% endif %}".Replace("#endsWith#", endsWith).RenderTemplate(sut));
@@ -540,9 +574,13 @@ namespace FifteenBelow.Deployment.Update.Tests
         public void EndsWith_EmptyString_Throws()
         {
             var sut = new TagDictionary("ident", @"<Structure xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"">
+                                                      <ClientCode>XX</ClientCode>
+                                                      <Environment>LOC</Environment>
                                                       <Properties>
                                                         <Property name=""Data"">Value</Property>
                                                       </Properties>
+                                                      <PropertyGroups />
+                                                      <DbLogins />
                                                   </Structure>");
 
             Assert.Throws<ArgumentException>(() => "{% if Data|endsWith:'' %}true{% else %}false{% endif %}".RenderTemplate(sut));
@@ -552,9 +590,13 @@ namespace FifteenBelow.Deployment.Update.Tests
         public void EndsWith_WhenPropertyDoesntExist_Throws()
         {
             var sut = new TagDictionary("ident", $@"<Structure xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"">
+                                                      <ClientCode>XX</ClientCode>
+                                                      <Environment>LOC</Environment>
                                                       <Properties>
                                                         <Property name=""Data"">Value</Property>
                                                       </Properties>
+                                                      <PropertyGroups />
+                                                      <DbLogins />
                                                   </Structure>");
 
             Assert.Throws<ArgumentException>(() => "{% if Undata|startsWith:'V' %}true{% else %}false{% endif %}".RenderTemplate(sut));
@@ -567,8 +609,11 @@ namespace FifteenBelow.Deployment.Update.Tests
         public void EndsWith_WhenPropertyDoesntExist_Defaulted(string value, string endsWith, bool expected)
         {
             var sut = new TagDictionary("ident", $@"<Structure xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"">
-                                                      <Properties>
-                                                      </Properties>
+                                                      <ClientCode>XX</ClientCode>
+                                                      <Environment>LOC</Environment>
+                                                      <Properties />
+                                                      <PropertyGroups />
+                                                      <DbLogins />
                                                   </Structure>");
 
             Assert.AreEqual(expected.ToString().ToLower(), "{% if Data|default:'#value#'|endsWith:'#endsWith#' %}true{% else %}false{% endif %}".Replace("#endsWith#", endsWith).Replace("#value#", value).RenderTemplate(sut));
@@ -581,10 +626,14 @@ namespace FifteenBelow.Deployment.Update.Tests
             string value = "fQF5wgZ4J9+lm2LbpqoxWeeao6A9x1XoIc3VTDSHBosJ1tM/mLX2XO8+AENaizmalFhCD1YKK4j7YmzEP72FwtfGgm2jazDGNb1WR440ZPL96P/tO/dKvy53KHtlkY76qFiP2KZPxRWjbem+5kpWn5lLczwl/7lQfBAM6ntawghntVAA7l7gwvKDuq2FcVIP3Njdu3DzSWPgP4P83pQxn04KtG7fO0VudUXjllI6Y/LAgpovYuC1SR3lTw33V4KVPXcOvB16bwplw+izKGWBn9Wjc6B0IxyW0tSz87ETzuL0HpiOeTZvEObrzSXlCjz3qbt4mf5gQ9QN4Gk7tLpOAZhrV1fn94IDL+l73KDbQDVo/HsX5sFFK1amFu7669kjlCOtiXxS9nZ35GtMVV2N+TC78xg0tAmYZtCOaJ+AgKoPj+PZTaR+Heu+nddiy7EAsezQ0FePxL1FN6+VcMydA16htdfdhwBzt/Sjql1LLoqSuaduOvXwftkOfhl3ylVRNnGjgHtIlAAEXtxfyitxVQSVVDgPRwfncB0S4LgpXrnuw+Bj7CuslXvCL6x9ZCp5PYqcXTYcwuv/xysFrTKM0k6xS4D6mIShlOwOxaMm0nntg3VBIXwJZULHabd/xMb2UkwQOAjKvgplLmduaSeGdS8axup326eSmEDRXQlHqUM=";
 
             var sut = new TagDictionary("ident", $@"<Structure xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"">
+                                                      <ClientCode>XX</ClientCode>
+                                                      <Environment>LOC</Environment>
                                                       <Properties>
                                                         <Property name=""Data"">{value}</Property>
                                                         <Property name=""Certificate"">XX-NON-Certificate</Property>
                                                       </Properties>
+                                                      <PropertyGroups />
+                                                      <DbLogins />
                                                   </Structure>");
 
             var expected = "hello";

--- a/src/15below.Deployment.Update.Tests/TagDictionaryTests.cs
+++ b/src/15below.Deployment.Update.Tests/TagDictionaryTests.cs
@@ -424,7 +424,7 @@ namespace FifteenBelow.Deployment.Update.Tests
                                                       </Properties>
                                                   </Structure>");
 
-            Assert.AreEqual(false.ToString().ToLower(), "{% if Undata|startsWith:'' %}true{% else %}false{% endif %}".RenderTemplate(sut));
+            Assert.AreEqual(new NDjangoWrapper.ErrorTemplate().ToString(), "{% if Undata|startsWith:'' %}true{% else %}false{% endif %}".RenderTemplate(sut));
         }
 
         [Test]
@@ -441,6 +441,51 @@ namespace FifteenBelow.Deployment.Update.Tests
                                                   </Structure>");
 
             Assert.AreEqual(expected.ToString().ToLower(), "{% if Data|startsWith:'#startsWith#' %}true{% else %}false{% endif %}".Replace("#startsWith#", startsWith).RenderTemplate(sut));
+        }
+
+        [Test]
+        [Explicit] // You can only run this with a specific certificate loaded into your computer
+        public void Decrypt_Test()
+        {
+            string value = "fQF5wgZ4J9+lm2LbpqoxWeeao6A9x1XoIc3VTDSHBosJ1tM/mLX2XO8+AENaizmalFhCD1YKK4j7YmzEP72FwtfGgm2jazDGNb1WR440ZPL96P/tO/dKvy53KHtlkY76qFiP2KZPxRWjbem+5kpWn5lLczwl/7lQfBAM6ntawghntVAA7l7gwvKDuq2FcVIP3Njdu3DzSWPgP4P83pQxn04KtG7fO0VudUXjllI6Y/LAgpovYuC1SR3lTw33V4KVPXcOvB16bwplw+izKGWBn9Wjc6B0IxyW0tSz87ETzuL0HpiOeTZvEObrzSXlCjz3qbt4mf5gQ9QN4Gk7tLpOAZhrV1fn94IDL+l73KDbQDVo/HsX5sFFK1amFu7669kjlCOtiXxS9nZ35GtMVV2N+TC78xg0tAmYZtCOaJ+AgKoPj+PZTaR+Heu+nddiy7EAsezQ0FePxL1FN6+VcMydA16htdfdhwBzt/Sjql1LLoqSuaduOvXwftkOfhl3ylVRNnGjgHtIlAAEXtxfyitxVQSVVDgPRwfncB0S4LgpXrnuw+Bj7CuslXvCL6x9ZCp5PYqcXTYcwuv/xysFrTKM0k6xS4D6mIShlOwOxaMm0nntg3VBIXwJZULHabd/xMb2UkwQOAjKvgplLmduaSeGdS8axup326eSmEDRXQlHqUM=";
+
+            var sut = new TagDictionary("ident", $@"<Structure xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"">
+                                                      <Properties>
+                                                        <Property name=""Data"">{value}</Property>
+                                                      </Properties>
+                                                  </Structure>");
+
+            var expected = "hello";
+
+            Assert.AreEqual(expected.ToString().ToLower(), "{{ Data|decrypt:'XX-NON-Certificate' }}".RenderTemplate(sut));
+        }
+
+        [Test]
+        public void EndsWith_WhenPropertyDoesntExist()
+        {
+            var sut = new TagDictionary("ident", $@"<Structure xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"">
+                                                      <Properties>
+                                                        <Property name=""Data"">Value</Property>
+                                                      </Properties>
+                                                  </Structure>");
+
+            Assert.AreEqual(new NDjangoWrapper.ErrorTemplate().ToString(), "{% if Undata|startsWith:'' %}true{% else %}false{% endif %}".RenderTemplate(sut));
+        }
+
+        [Test]
+        [TestCase("Hello", "o", true)]
+        [TestCase("Goodbye", "o", false)]
+        [TestCase("", "h", false)]
+        [TestCase("Empty", "", true)]
+        public void EndsWith_True(string value, string endsWith, bool expected)
+        {
+            var sut = new TagDictionary("ident", $@"<Structure xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"">
+                                                      <Properties>
+                                                        <Property name=""Data"">{value}</Property>
+                                                      </Properties>
+                                                  </Structure>");
+
+            Assert.AreEqual(expected.ToString().ToLower(), "{% if Data|endsWith:'#endsWith#' %}true{% else %}false{% endif %}".Replace("#endsWith#", endsWith).RenderTemplate(sut));
         }
 
         [Test]

--- a/src/15below.Deployment.Update.Tests/TagDictionaryTests.cs
+++ b/src/15below.Deployment.Update.Tests/TagDictionaryTests.cs
@@ -395,24 +395,52 @@ namespace FifteenBelow.Deployment.Update.Tests
         }
 
         [Test]
-        public void WhenPropertyDoesntExist_UseDeault()
+        public void WhenPropertyDoesntExist_UseDefault()
         {
             var sut = new TagDictionary("ident", new Dictionary<TagSource, string> { { TagSource.XmlData, XmlData } });
             Assert.AreEqual("default", "{{ NotAValue|default:\"default\" }}".RenderTemplate(sut));
         }
 
         [Test]
-        public void WhenPropertyDoesntExist_ValueInt_UseDeault()
+        public void WhenPropertyDoesntExist_ValueInt_UseDefault()
         {
             var sut = new TagDictionary("ident", new Dictionary<TagSource, string> { { TagSource.XmlData, XmlData } });
             Assert.AreEqual("1", "{{ NotAValue|default:1 }}".RenderTemplate(sut));
         }
 
         [Test]
-        public void WhenPropertyDoesntExist_ValueSingleQuote_UseDeault()
+        public void WhenPropertyDoesntExist_ValueSingleQuote_UseDefault()
         {
             var sut = new TagDictionary("ident", new Dictionary<TagSource, string> { { TagSource.XmlData, XmlData } });
             Assert.AreEqual("default", "{{ NotAValue|default:'default' }}".RenderTemplate(sut));
+        }
+
+        [Test]
+        public void StartsWith_WhenPropertyDoesntExist()
+        {
+            var sut = new TagDictionary("ident", $@"<Structure xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"">
+                                                      <Properties>
+                                                        <Property name=""Data"">Value</Property>
+                                                      </Properties>
+                                                  </Structure>");
+
+            Assert.AreEqual(false.ToString().ToLower(), "{% if Undata|startsWith:'' %}true{% else %}false{% endif %}".RenderTemplate(sut));
+        }
+
+        [Test]
+        [TestCase("Hello", "h", true)]
+        [TestCase("Goodbye", "h", false)]
+        [TestCase("", "h", false)]
+        [TestCase("Empty", "", true)]
+        public void StartsWith_True(string value, string startsWith, bool expected)
+        {
+            var sut = new TagDictionary("ident", $@"<Structure xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"">
+                                                      <Properties>
+                                                        <Property name=""Data"">{value}</Property>
+                                                      </Properties>
+                                                  </Structure>");
+
+            Assert.AreEqual(expected.ToString().ToLower(), "{% if Data|startsWith:'#startsWith#' %}true{% else %}false{% endif %}".Replace("#startsWith#", startsWith).RenderTemplate(sut));
         }
 
         [Test]

--- a/src/15below.Deployment.Update.Tests/TagDictionaryTests.cs
+++ b/src/15below.Deployment.Update.Tests/TagDictionaryTests.cs
@@ -416,6 +416,59 @@ namespace FifteenBelow.Deployment.Update.Tests
         }
 
         [Test]
+        [TestCase("Hello", "el", true)]
+        [TestCase("Goodbye", "el", false)]
+        [TestCase("", "el", false)]
+        public void Contains(string value, string contains, bool expected)
+        {
+            var sut = new TagDictionary("ident", $@"<Structure xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"">
+                                                      <Properties>
+                                                        <Property name=""Data"">{value}</Property>
+                                                      </Properties>
+                                                  </Structure>");
+
+            Assert.AreEqual(expected.ToString().ToLower(), "{% if Data|contains:'#contains#' %}true{% else %}false{% endif %}".Replace("#contains#", contains).RenderTemplate(sut));
+        }
+
+        [Test]
+        public void Contains_EmptyString_Throws()
+        {
+            var sut = new TagDictionary("ident", @"<Structure xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"">
+                                                      <Properties>
+                                                        <Property name=""Data"">Value</Property>
+                                                      </Properties>
+                                                  </Structure>");
+
+            Assert.Throws<ArgumentException>(() => "{% if Data|contains:'' %}true{% else %}false{% endif %}".RenderTemplate(sut));
+        }
+
+        [Test]
+        public void Contains_WhenPropertyDoesntExist_Throws()
+        {
+            var sut = new TagDictionary("ident", $@"<Structure xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"">
+                                                      <Properties>
+                                                        <Property name=""Data"">Value</Property>
+                                                      </Properties>
+                                                  </Structure>");
+
+            Assert.Throws<ArgumentException>(() => "{% if Undata|contains:'al' %}true{% else %}false{% endif %}".RenderTemplate(sut));
+        }
+
+        [Test]
+        [TestCase("Hello", "el", true)]
+        [TestCase("Goodbye", "el", false)]
+        [TestCase("", "el", false)]
+        public void Contains_WhenPropertyDoesntExist_Defaulted(string value, string contains, bool expected)
+        {
+            var sut = new TagDictionary("ident", $@"<Structure xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"">
+                                                      <Properties>
+                                                      </Properties>
+                                                  </Structure>");
+
+            Assert.AreEqual(expected.ToString().ToLower(), "{% if Data|default:'#value#'|contains:'#endsWith#' %}true{% else %}false{% endif %}".Replace("#endsWith#", contains).Replace("#value#", value).RenderTemplate(sut));
+        }
+
+        [Test]
         [TestCase("Hello", "h", true)]
         [TestCase("Goodbye", "h", false)]
         [TestCase("", "h", false)]

--- a/src/15below.Deployment.Update/15below.Deployment.Update.csproj
+++ b/src/15below.Deployment.Update/15below.Deployment.Update.csproj
@@ -58,6 +58,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DictionaryExtensions.cs" />
+    <Compile Include="NDjangoExpansions\DecryptFilter.cs" />
+    <Compile Include="NDjangoExpansions\EndsWithFilter.cs" />
     <Compile Include="NDjangoExpansions\StartsWithFilter.cs" />
     <Compile Include="SubTagDictionary.cs" />
     <Compile Include="NDjangoExpansions\ConcatFilter.cs" />

--- a/src/15below.Deployment.Update/15below.Deployment.Update.csproj
+++ b/src/15below.Deployment.Update/15below.Deployment.Update.csproj
@@ -59,6 +59,7 @@
   <ItemGroup>
     <Compile Include="DictionaryExtensions.cs" />
     <Compile Include="NDjangoExpansions\DecryptFilter.cs" />
+    <Compile Include="NDjangoExpansions\ContainsFilter.cs" />
     <Compile Include="NDjangoExpansions\EndsWithFilter.cs" />
     <Compile Include="NDjangoExpansions\StartsWithFilter.cs" />
     <Compile Include="SubTagDictionary.cs" />

--- a/src/15below.Deployment.Update/15below.Deployment.Update.csproj
+++ b/src/15below.Deployment.Update/15below.Deployment.Update.csproj
@@ -58,6 +58,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DictionaryExtensions.cs" />
+    <Compile Include="NDjangoExpansions\StartsWithFilter.cs" />
     <Compile Include="SubTagDictionary.cs" />
     <Compile Include="NDjangoExpansions\ConcatFilter.cs" />
     <Compile Include="NDjangoExpansions\EmptyFilter.cs" />

--- a/src/15below.Deployment.Update/NDjangoExpansions/ContainsFilter.cs
+++ b/src/15below.Deployment.Update/NDjangoExpansions/ContainsFilter.cs
@@ -1,0 +1,35 @@
+﻿using NDjango.Interfaces;
+using System;
+
+namespace FifteenBelow.Deployment.Update.NDjangoExpansions
+{
+    [Name("contains")]
+    public class ContainsFilter : IFilter
+    {
+        public object Perform(object value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object PerformWithParam(object value, object parameter)
+        {
+            if (!(parameter is string s) || String.IsNullOrEmpty(s))
+            {
+                throw new Exception($"contains parameter must be a non-empty string");
+            }
+            else if (value is NDjangoWrapper.ErrorTemplate)
+            {
+                throw new Exception($"Value does not exist when calling contains");
+            }
+            else
+            {
+                return (value ?? "").ToString().IndexOf((parameter ?? "").ToString(), StringComparison.CurrentCultureIgnoreCase) >= 0;
+            }
+        }
+
+        public object DefaultValue
+        {
+            get { return null; }
+        }
+    }
+}

--- a/src/15below.Deployment.Update/NDjangoExpansions/DecryptFilter.cs
+++ b/src/15below.Deployment.Update/NDjangoExpansions/DecryptFilter.cs
@@ -1,0 +1,68 @@
+﻿using NDjango.Interfaces;
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+namespace FifteenBelow.Deployment.Update.NDjangoExpansions
+{
+    [Name("decrypt")]
+    public class DecryptFilter : IFilter
+    {
+        public object Perform(object value)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object PerformWithParam(object value, object parameter)
+        {
+            var cert = LoadCertificate(StoreName.My, StoreLocation.LocalMachine, $"CN={(string)parameter}");
+
+            if (cert == null)
+            {
+                return new NDjangoWrapper.ErrorTemplate();
+            }
+            else
+            {
+                var data = Convert.FromBase64String((string)value);
+                var decrypted = DecryptData(cert, data);
+                return Encoding.UTF8.GetString(decrypted);
+            }
+        }
+
+        public object DefaultValue
+        {
+            get { return null; }
+        }
+
+        private X509Certificate2 LoadCertificate(StoreName storeName, StoreLocation location, string subjectName)
+        {
+            X509Store store = new X509Store(storeName, location);
+
+            try
+            {
+                store.Open(OpenFlags.ReadOnly);
+
+                foreach (X509Certificate2 certificate in store.Certificates)
+                {
+                    if (certificate.SubjectName.Name == subjectName)
+                    {
+                        return certificate;
+                    }
+                }
+
+                return null;
+            }
+            finally
+            {
+                store.Close();
+            }
+        }
+
+        private byte[] DecryptData(X509Certificate2 cert, byte[] data)
+        {
+            var rsa = (RSACryptoServiceProvider)cert.PrivateKey;
+            return rsa.Decrypt(data, false);
+        }
+    }
+}

--- a/src/15below.Deployment.Update/NDjangoExpansions/EndsWithFilter.cs
+++ b/src/15below.Deployment.Update/NDjangoExpansions/EndsWithFilter.cs
@@ -3,8 +3,8 @@ using System;
 
 namespace FifteenBelow.Deployment.Update.NDjangoExpansions
 {
-    [Name("startsWith")]
-    public class StartsWithFilter : IFilter
+    [Name("endsWith")]
+    public class EndsWithFilter : IFilter
     {
         public object Perform(object value)
         {
@@ -19,7 +19,7 @@ namespace FifteenBelow.Deployment.Update.NDjangoExpansions
             }
             else
             {
-                return (value ?? "").ToString().StartsWith((parameter ?? "").ToString(), StringComparison.CurrentCultureIgnoreCase);
+                return (value ?? "").ToString().EndsWith((parameter ?? "").ToString(), StringComparison.CurrentCultureIgnoreCase);
             }
         }
 

--- a/src/15below.Deployment.Update/NDjangoExpansions/EndsWithFilter.cs
+++ b/src/15below.Deployment.Update/NDjangoExpansions/EndsWithFilter.cs
@@ -13,9 +13,13 @@ namespace FifteenBelow.Deployment.Update.NDjangoExpansions
 
         public object PerformWithParam(object value, object parameter)
         {
-            if (value is NDjangoWrapper.ErrorTemplate)
+            if (!(parameter is string s) || String.IsNullOrEmpty(s))
             {
-                return value;
+                throw new Exception($"endsWith parameter must be a non-empty string");
+            }
+            else if (value is NDjangoWrapper.ErrorTemplate)
+            {
+                throw new Exception($"Value does not exist when calling endsWith");
             }
             else
             {

--- a/src/15below.Deployment.Update/NDjangoExpansions/StartsWithFilter.cs
+++ b/src/15below.Deployment.Update/NDjangoExpansions/StartsWithFilter.cs
@@ -13,7 +13,9 @@ namespace FifteenBelow.Deployment.Update.NDjangoExpansions
 
         public object PerformWithParam(object value, object parameter)
         {
-            return value is NDjangoWrapper.ErrorTemplate ? false : (value ?? "").ToString().StartsWith((parameter ?? "").ToString(), StringComparison.CurrentCultureIgnoreCase);
+            return (value is NDjangoWrapper.ErrorTemplate)
+                   ? false
+                   : (value ?? "").ToString().StartsWith((parameter ?? "").ToString(), StringComparison.CurrentCultureIgnoreCase);
         }
 
         public object DefaultValue

--- a/src/15below.Deployment.Update/NDjangoExpansions/StartsWithFilter.cs
+++ b/src/15below.Deployment.Update/NDjangoExpansions/StartsWithFilter.cs
@@ -1,0 +1,24 @@
+﻿using NDjango.Interfaces;
+using System;
+
+namespace FifteenBelow.Deployment.Update.NDjangoExpansions
+{
+    [Name("startsWith")]
+    public class StartsWithFilter : IFilter
+    {
+        public object Perform(object value)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public object PerformWithParam(object value, object parameter)
+        {
+            return value is NDjangoWrapper.ErrorTemplate ? false : (value ?? "").ToString().StartsWith((parameter ?? "").ToString(), StringComparison.CurrentCultureIgnoreCase);
+        }
+
+        public object DefaultValue
+        {
+            get { return null; }
+        }
+    }
+}

--- a/src/15below.Deployment.Update/NDjangoExpansions/StartsWithFilter.cs
+++ b/src/15below.Deployment.Update/NDjangoExpansions/StartsWithFilter.cs
@@ -13,9 +13,13 @@ namespace FifteenBelow.Deployment.Update.NDjangoExpansions
 
         public object PerformWithParam(object value, object parameter)
         {
-            if (value is NDjangoWrapper.ErrorTemplate)
+            if (!(parameter is string s) || String.IsNullOrEmpty(s))
             {
-                return value;
+                throw new Exception($"startsWith parameter must be a non-empty string");
+            }
+            else if (value is NDjangoWrapper.ErrorTemplate)
+            {
+                throw new Exception($"Value does not exist when calling startsWith");
             }
             else
             {

--- a/src/15below.Deployment.Update/NDjangoWrapper.cs
+++ b/src/15below.Deployment.Update/NDjangoWrapper.cs
@@ -26,6 +26,7 @@ namespace FifteenBelow.Deployment.Update
                                                 .WithFilter("default", new NDjangoExpansions.DefaultFilter())
                                                 .WithFilter("exists", new NDjangoExpansions.ExistsFilter())
                                                 .WithFilter("empty", new NDjangoExpansions.EmptyFilter())
+                                                .WithFilter("contains", new NDjangoExpansions.ContainsFilter())
                                                 .WithFilter("startsWith", new NDjangoExpansions.StartsWithFilter())
                                                 .WithFilter("endsWith", new NDjangoExpansions.EndsWithFilter())
                                                 .WithFilter("decrypt", new NDjangoExpansions.DecryptFilter())

--- a/src/15below.Deployment.Update/NDjangoWrapper.cs
+++ b/src/15below.Deployment.Update/NDjangoWrapper.cs
@@ -27,6 +27,8 @@ namespace FifteenBelow.Deployment.Update
                                                 .WithFilter("exists", new NDjangoExpansions.ExistsFilter())
                                                 .WithFilter("empty", new NDjangoExpansions.EmptyFilter())
                                                 .WithFilter("startsWith", new NDjangoExpansions.StartsWithFilter())
+                                                .WithFilter("endsWith", new NDjangoExpansions.EndsWithFilter())
+                                                .WithFilter("decrypt", new NDjangoExpansions.DecryptFilter())
                                                 .GetNewManager();
         }
 

--- a/src/15below.Deployment.Update/NDjangoWrapper.cs
+++ b/src/15below.Deployment.Update/NDjangoWrapper.cs
@@ -46,6 +46,7 @@ namespace FifteenBelow.Deployment.Update
         {
             lock (Error)
             {
+                string exceptionMessage = null;
                 string replacementValue;
 
                 try
@@ -53,8 +54,9 @@ namespace FifteenBelow.Deployment.Update
                     Error.Invoked = false;
                     replacementValue = templateManager.RenderTemplate(StringProvider + template, values).ReadToEnd();
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    exceptionMessage = $"\n{ex.Message}";
                     replacementValue = string.Empty;
                     Error.Invoked = true;
                 }
@@ -63,11 +65,11 @@ namespace FifteenBelow.Deployment.Update
                 {
                     if (string.IsNullOrWhiteSpace(replacementValue) || !replacementValue.Contains(Error.ToString()))
                     {
-                        throw new ArgumentException(string.Format("Tag substitution errored on template string:\n{0}", template));
+                        throw new ArgumentException(string.Format("Tag substitution errored on template string:\n{0}{1}", template, exceptionMessage));
                     }
 
                     var attemptedRender = replacementValue.Replace(Error.ToString(), "[ERROR OCCURRED HERE]");
-                    throw new ArgumentException(string.Format("Tag substitution failed on template string:\n{0}\n\nAttempted rendering was:\n{1}", template, attemptedRender));
+                    throw new ArgumentException(string.Format("Tag substitution failed on template string:\n{0}\n\nAttempted rendering was:\n{1}{2}", template, attemptedRender, exceptionMessage));
                 }
 
                 return replacementValue;

--- a/src/15below.Deployment.Update/NDjangoWrapper.cs
+++ b/src/15below.Deployment.Update/NDjangoWrapper.cs
@@ -26,6 +26,7 @@ namespace FifteenBelow.Deployment.Update
                                                 .WithFilter("default", new NDjangoExpansions.DefaultFilter())
                                                 .WithFilter("exists", new NDjangoExpansions.ExistsFilter())
                                                 .WithFilter("empty", new NDjangoExpansions.EmptyFilter())
+                                                .WithFilter("startsWith", new NDjangoExpansions.StartsWithFilter())
                                                 .GetNewManager();
         }
 

--- a/src/15below.Deployment.Update/Properties/AssemblyInfo.cs
+++ b/src/15below.Deployment.Update/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.4.0")]
-[assembly: AssemblyVersion("1.0.4.0")]
-[assembly: AssemblyFileVersion("1.0.4.0")]
+// [assembly: AssemblyVersion("1.0.5.0")]
+[assembly: AssemblyVersion("1.0.5.0")]
+[assembly: AssemblyFileVersion("1.0.5.0")]
 [assembly: AssemblyInformationalVersion("1.0.0-feature-Ma-local")]

--- a/src/Ensconce.Database.Tests/Properties/AssemblyInfo.cs
+++ b/src/Ensconce.Database.Tests/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.4.0")]
-[assembly: AssemblyVersion("1.0.4.0")]
-[assembly: AssemblyFileVersion("1.0.4.0")]
+// [assembly: AssemblyVersion("1.0.5.0")]
+[assembly: AssemblyVersion("1.0.5.0")]
+[assembly: AssemblyFileVersion("1.0.5.0")]
 [assembly: AssemblyInformationalVersion("1.0.0-feature-Ma-local")]

--- a/src/Ensconce/Properties/AssemblyInfo.cs
+++ b/src/Ensconce/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.4.0")]
-[assembly: AssemblyVersion("1.0.4.0")]
-[assembly: AssemblyFileVersion("1.0.4.0")]
+// [assembly: AssemblyVersion("1.0.5.0")]
+[assembly: AssemblyVersion("1.0.5.0")]
+[assembly: AssemblyFileVersion("1.0.5.0")]
 [assembly: AssemblyInformationalVersion("1.0.0-feature-Ma-local")]

--- a/src/Scripts/userManagement.ps1
+++ b/src/Scripts/userManagement.ps1
@@ -1,26 +1,26 @@
 Write-Host "Ensconce - UserManagement Loading"
 # ADS_USER_FLAG_ENUM Enumeration
 # http://msdn.microsoft.com/en-us/library/aa772300(VS.85).aspx
-$ADS_UF_SCRIPT                 = 1   # 0x1
-$ADS_UF_ACCOUNTDISABLE             = 2   # 0x2
-$ADS_UF_HOMEDIR_REQUIRED            = 8   # 0x8
-$ADS_UF_LOCKOUT                 = 16  # 0x10
-$ADS_UF_PASSWD_NOTREQD             = 32  # 0x20
-$ADS_UF_PASSWD_CANT_CHANGE           = 64  # 0x40
-$ADS_UF_ENCRYPTED_TEXT_PASSWORD_ALLOWED     = 128  # 0x80
-$ADS_UF_TEMP_DUPLICATE_ACCOUNT         = 256  # 0x100
-$ADS_UF_NORMAL_ACCOUNT             = 512  # 0x200
-$ADS_UF_INTERDOMAIN_TRUST_ACCOUNT        = 2048  # 0x800
-$ADS_UF_WORKSTATION_TRUST_ACCOUNT        = 4096  # 0x1000
-$ADS_UF_SERVER_TRUST_ACCOUNT          = 8192  # 0x2000
-$ADS_UF_DONT_EXPIRE_PASSWD           = 65536  # 0x10000
-$ADS_UF_MNS_LOGON_ACCOUNT            = 131072 # 0x20000
-$ADS_UF_SMARTCARD_REQUIRED           = 262144 # 0x40000
-$ADS_UF_TRUSTED_FOR_DELEGATION         = 524288 # 0x80000
-$ADS_UF_NOT_DELEGATED              = 1048576 # 0x100000
-$ADS_UF_USE_DES_KEY_ONLY            = 2097152 # 0x200000
-$ADS_UF_DONT_REQUIRE_PREAUTH          = 4194304 # 0x400000
-$ADS_UF_PASSWORD_EXPIRED            = 8388608 # 0x800000
+$ADS_UF_SCRIPT                                 = 1        # 0x1
+$ADS_UF_ACCOUNTDISABLE                         = 2        # 0x2
+$ADS_UF_HOMEDIR_REQUIRED                       = 8        # 0x8
+$ADS_UF_LOCKOUT                                = 16       # 0x10
+$ADS_UF_PASSWD_NOTREQD                         = 32       # 0x20
+$ADS_UF_PASSWD_CANT_CHANGE                     = 64       # 0x40
+$ADS_UF_ENCRYPTED_TEXT_PASSWORD_ALLOWED        = 128      # 0x80
+$ADS_UF_TEMP_DUPLICATE_ACCOUNT                 = 256      # 0x100
+$ADS_UF_NORMAL_ACCOUNT                         = 512      # 0x200
+$ADS_UF_INTERDOMAIN_TRUST_ACCOUNT              = 2048     # 0x800
+$ADS_UF_WORKSTATION_TRUST_ACCOUNT              = 4096     # 0x1000
+$ADS_UF_SERVER_TRUST_ACCOUNT                   = 8192     # 0x2000
+$ADS_UF_DONT_EXPIRE_PASSWD                     = 65536    # 0x10000
+$ADS_UF_MNS_LOGON_ACCOUNT                      = 131072   # 0x20000
+$ADS_UF_SMARTCARD_REQUIRED                     = 262144   # 0x40000
+$ADS_UF_TRUSTED_FOR_DELEGATION                 = 524288   # 0x80000
+$ADS_UF_NOT_DELEGATED                          = 1048576  # 0x100000
+$ADS_UF_USE_DES_KEY_ONLY                       = 2097152  # 0x200000
+$ADS_UF_DONT_REQUIRE_PREAUTH                   = 4194304  # 0x400000
+$ADS_UF_PASSWORD_EXPIRED                       = 8388608  # 0x800000
 $ADS_UF_TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION = 16777216 # 0x1000000
 
 Function AddUser([string]$name, [string]$password)


### PR DESCRIPTION
Functions to support string contains / startsWith / endsWith, and the ability to decrypt data using a certificate.

Examples:
{% if SomeValue|contains:'15below' %}true{% else %}false{% endif %}
{% if URL|startsWith:'https://' %}true{% else %}false{% endif %}
{% if HostName|endsWith:'.com' %}true{% else %}false{% endif %}
{{ EncryptedValue|decrypt:Certificate }} // decrypts the value using a certificate in the certificate store

Where Certificate would be a string of the CN of the certificate, i.e. "XX-NON-Certificate"
