### PR TITLE
When encountering errors in tag replacement, dump out the in memory state of the xml structure to a new file to aid debugging.

### DIFF
--- a/src/15below.Deployment.Update.Tests/UpdateFileTests.cs
+++ b/src/15below.Deployment.Update.Tests/UpdateFileTests.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Xml;
 using System.Xml.Linq;
@@ -87,6 +88,15 @@ namespace FifteenBelow.Deployment.Update.Tests
         public void ThrowNewMissingArgExceptionIfNoTagValue()
         {
             Assert.Throws<ArgumentException>(() => UpdateFile.Update(@"TestUpdateFiles\TestSubstitution5.xml", @"TestUpdateFiles\TestConfig1.xml"));
+        }
+
+        [Test]
+        public void CreatePartialOutputFileIFExceptionDuringProcess()
+        {
+            Assert.Throws<ArgumentException>(() => UpdateFile.Update(@"TestUpdateFiles\TestSubstitution5.xml", @"TestUpdateFiles\TestConfig1.xml"));
+            var fileName = @"TestUpdateFiles\TestConfig1.xml_partial";
+
+            Assert.IsTrue(File.Exists(fileName));
         }
 
         [Test]

--- a/src/15below.Deployment.Update/UpdateFile.cs
+++ b/src/15below.Deployment.Update/UpdateFile.cs
@@ -101,7 +101,17 @@ namespace FifteenBelow.Deployment.Update
             {
                 if (baseData == null) baseData = File.ReadAllText(baseFile);
                 var baseXml = XDocument.Parse(baseData);
-                return UpdateXml(tagValues, subs, baseXml, nsm, subsXml);
+                try
+                {
+                    return UpdateXml(tagValues, subs, baseXml, nsm, subsXml);
+                }
+                catch (Exception)
+                {
+                    var partialFilename = $"{baseFile}_partial";
+                    baseXml.Save(partialFilename);
+
+                    throw;
+                }
             }
 
             return baseData;


### PR DESCRIPTION
plus a test!

Was thinking maybe this should be switch sent into Ensconce command line, whaddya think?