### PR TITLE
Add logic to turn a subsitution off and on

### DIFF
--- a/src/Ensconce.Database.Tests/TemporaryDatabaseTests.cs
+++ b/src/Ensconce.Database.Tests/TemporaryDatabaseTests.cs
@@ -114,9 +114,7 @@ namespace Ensconce.Database.Tests
 
                 var args = logger.GetArgumentsForCallsMadeOn(x => x.log_a_warning_event_containing(null, null));
 
-                Assert.That(args[0],
-                            Has.None.ContainsSubstring(
-                                "Had an error building session factory from merged, attempting unmerged. The error:"));
+                Assert.That(args[0], Has.None.ContainsSubstring("Had an error building session factory from merged, attempting unmerged. The error:"));
             }
         }
 

--- a/src/Ensconce.Update.Tests/Ensconce.Update.Tests.csproj
+++ b/src/Ensconce.Update.Tests/Ensconce.Update.Tests.csproj
@@ -81,6 +81,10 @@
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <Content Include="TestUpdateFiles\TestSubstitution30.xml">
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="TestUpdateFiles\TestSubstitution29.xml">
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/src/Ensconce.Update.Tests/TestUpdateFiles/TestSubstitution30.xml
+++ b/src/Ensconce.Update.Tests/TestUpdateFiles/TestSubstitution30.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Root xmlns="http://15below.com/Substitutions.xsd">
+  <Namespaces/>
+  <Files>
+    <File Filename="TestUpdateFiles\TestConfig3.xml">
+      <Changes>
+        <Change type="ChangeAttribute" XPath="/root/value" attributeName="myAttr" value="after" if="Environment == 'INT'" />
+      </Changes>
+    </File>
+  </Files>
+</Root>

--- a/src/Ensconce.Update.Tests/TestUpdateFiles/TestSubstitution30.xml
+++ b/src/Ensconce.Update.Tests/TestUpdateFiles/TestSubstitution30.xml
@@ -4,7 +4,7 @@
   <Files>
     <File Filename="TestUpdateFiles\TestConfig3.xml">
       <Changes>
-        <Change type="ChangeAttribute" XPath="/root/value" attributeName="myAttr" value="after" if="Environment == 'INT'" />
+        <Change type="ChangeAttribute" xPath="/root/value" attributeName="myAttr" value="after" if="Environment == 'INT'" />
       </Changes>
     </File>
   </Files>

--- a/src/Ensconce.Update.Tests/UpdateFileTests.cs
+++ b/src/Ensconce.Update.Tests/UpdateFileTests.cs
@@ -409,5 +409,27 @@ namespace Ensconce.Update.Tests
             Assert.AreEqual("new-after", newConfig.XPathSelectElement("/root/testing/test[2]").Attribute("myAttr").Value);
             Assert.AreEqual("new-value", newConfig.XPathSelectElement("/root/testing/test[2]").Value);
         }
+
+        [Test]
+        public void SubstituteIf_True()
+        {
+            var newConfig = XDocument.Parse(UpdateFile.Update(
+                @"TestUpdateFiles\TestSubstitution30.xml", @"TestUpdateFiles\TestConfig3.xml",
+                new Dictionary<string, object> { { "Environment", "INT" } }
+            ));
+
+            Assert.AreEqual("after", newConfig.XPathSelectElement("/root/value").Attribute("myAttr").Value);
+        }
+
+        [Test]
+        public void SubstituteIf_False()
+        {
+            var newConfig = XDocument.Parse(UpdateFile.Update(
+                @"TestUpdateFiles\TestSubstitution30.xml", @"TestUpdateFiles\TestConfig3.xml",
+                new Dictionary<string, object> { { "Environment", "NOT_INT" } }
+            ));
+
+            Assert.AreEqual("before", newConfig.XPathSelectElement("/root/value").Attribute("myAttr").Value);
+        }
     }
 }

--- a/src/Ensconce.Update/Substitutions.xsd
+++ b/src/Ensconce.Update/Substitutions.xsd
@@ -77,6 +77,7 @@
                               <xs:attribute name="attributeName" type="xs:string" use="optional"/>
                               <xs:attribute name="value" type="xs:string" use="optional"/>
                               <xs:attribute name="ifNotExists" type="xs:string" use="optional"/>
+                              <xs:attribute name="if" type="xs:string" use="optional"/>
                             </xs:complexType>
                           </xs:element>
                         </xs:sequence>

--- a/src/Ensconce.Update/UpdateFile.cs
+++ b/src/Ensconce.Update/UpdateFile.cs
@@ -24,6 +24,7 @@ namespace Ensconce.Update
             public string AddChildContent;
             public string AddChildContentIfNotExists;
             public bool HasAddChildContent;
+            public bool Execute;
 
             public Substitution()
             {
@@ -37,6 +38,7 @@ namespace Ensconce.Update
                 AddChildContent = "";
                 AddChildContentIfNotExists = "";
                 HasAddChildContent = false;
+                Execute = true;
             }
         }
 
@@ -161,7 +163,7 @@ namespace Ensconce.Update
                 baseNsm.AddNamespace(ns.Prefix, ns.Uri);
             }
 
-            foreach (var sub in subs)
+            foreach (var sub in subs.Where(x => x.Execute))
             {
                 Logging.Log($"Updating xpath {sub.XPath}");
 
@@ -264,6 +266,11 @@ namespace Ensconce.Update
                 }
 
                 sub.XPath = change.Attribute("xPath")?.Value.RenderTemplate(tagValues);
+
+                if (change.Attribute("if") != null)
+                {
+                    sub.Execute = bool.Parse($"{{% if {change.Attribute("if")?.Value} %}}true{{% else %}}false{{% endif %}}".RenderTemplate(tagValues));
+                }
             }
 
             return sub;


### PR DESCRIPTION
This uses a "if" with any django if statement.
This if statement gets created into correct NDjango to validate

example:
```
<?xml version="1.0" encoding="utf-8" ?>
<Root xmlns="http://15below.com/Substitutions.xsd">
  <Namespaces/>
  <Files>
    <File Filename="TestUpdateFiles\TestConfig3.xml">
      <Changes>
        <Change type="ChangeAttribute" XPath="/root/value" attributeName="myAttr" value="after" if="Environment == 'INT'" />
      </Changes>
    </File>
  </Files>
</Root>
```

Dependent on https://github.com/15below/Ensconce/pull/86
_This PR contains everything which is also in that PR_