### PR TITLE
Rather than hard failing when structure file cannot be found, just log warning

### DIFF
--- a/src/Ensconce.Console/TextRendering.cs
+++ b/src/Ensconce.Console/TextRendering.cs
@@ -25,12 +25,13 @@ namespace Ensconce.Console
 
             var fixedPath = Arguments.FixedPath.RenderTemplate(tags);
 
-            if (!File.Exists(fixedPath))
+            if (File.Exists(fixedPath))
             {
-                throw new FileNotFoundException($"Unable to locate structure file at {fixedPath}", fixedPath);
+                return BuildTagDictionary(instanceName, fixedPath, tags.Value);
             }
 
-            return BuildTagDictionary(instanceName, fixedPath, tags.Value);
+            Logging.Log("WARNING: The fixed structure path was not located at '{0}' so running without it!", fixedPath);
+            return tags.Value;
         }
 
         private static TagDictionary BuildTagDictionary(string instanceName)

--- a/src/Ensconce.Update/TagDictionary.cs
+++ b/src/Ensconce.Update/TagDictionary.cs
@@ -32,7 +32,7 @@ namespace Ensconce.Update
         public static TagDictionary FromIdentifier(string identifier)
         {
             var tagDictionary = new TagDictionary();
-            tagDictionary.LoadDictionary(identifier, new Dictionary<TagSource, string>());
+            tagDictionary.LoadDictionary(identifier, new Dictionary<TagSource, string> { { TagSource.Environment, "" } });
             return tagDictionary;
         }
 


### PR DESCRIPTION
This means if Ensconce is used to copy the fixed structure file you get a warning on that step, but it will still work.
But if a step fails because it cannot correctly parse tags, you will have a warning that there is no fixed structure file