### PR TITLE
Exception output to include inner exceptions, and ignoring certain exceptions from Retry

### DIFF
--- a/src/Ensconce.Console/Ensconce.Console.csproj
+++ b/src/Ensconce.Console/Ensconce.Console.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Backup.cs" />
     <Compile Include="DatabaseInteraction.cs" />
     <Compile Include="DictionaryExport.cs" />
+    <Compile Include="ExceptionDetails.cs" />
     <Compile Include="FileInteraction.cs" />
     <Compile Include="Options.cs" />
     <Compile Include="Program.cs" />

--- a/src/Ensconce.Console/ExceptionDetails.cs
+++ b/src/Ensconce.Console/ExceptionDetails.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Ensconce.Console
+{
+    public static class ExceptionDetails
+    {
+        public static string GetDetails(string message, Exception ex)
+        {
+            var sb = new StringBuilder(message);
+
+            if (!message.EndsWith(Environment.NewLine)) sb.Append(Environment.NewLine);
+
+            Recurse(sb, ex, 0);
+
+            return sb.ToString();
+        }
+
+        private static void Recurse(StringBuilder sb, Exception ex, int level = 0, int index = -1)
+        {
+            if (ex == null) return;
+
+            if (ex is AggregateException agg)
+            {
+                Print(sb, ex, level, index);
+
+                int i = 0;
+
+                foreach (var subEx in agg.InnerExceptions)
+                {
+                    Recurse(sb, subEx, level + 1, i++);
+                }
+            }
+            else
+            {
+                Recurse(sb, ex.InnerException, level);
+
+                Print(sb, ex, level, index);
+            }
+        }
+
+        private static void Print(StringBuilder sb, Exception ex, int level = 0, int index = -1)
+        {
+            var message = ex.Message.EndsWith(Environment.NewLine) ? ex.Message : $"{ex.Message}{Environment.NewLine}";
+
+            if (ex.StackTrace != null)
+            {
+                string stackTrace = Tidy(ex.StackTrace, level);
+                sb.Append($"{Environment.NewLine}{new string(' ', level * 3)}>> {(index >= 0 ? $"#{index} " : "")}{ex.GetType().Name}: {message}{Environment.NewLine}{stackTrace}{Environment.NewLine}");
+            }
+            else
+            {
+                sb.Append($"{Environment.NewLine}{new string(' ', level * 3)}>> {(index >= 0 ? $"#{index} " : "")}{ex.GetType().Name}: {message}");
+            }
+        }
+
+        private const string IgnoreTaskAwaiter = "System.Runtime.CompilerServices.TaskAwaiter";
+        private const string IgnoreTaskContinuation = "System.Threading.Tasks.ContinuationResultTaskFromResultTask";
+        private const string IgnoreTaskExecute = "System.Threading.Tasks.Task.Execute()";
+        private const string IgnoreTaskInnerInvoke = "System.Threading.Tasks.Task`1.InnerInvoke()";
+        private const string IgnoreTaskGetResultCore = "System.Threading.Tasks.Task`1.GetResultCore";
+        private const string IgnoreTaskGetResult = "System.Threading.Tasks.Task`1.get_Result";
+        private const string IgnoreTaskFactory = "System.Threading.Tasks.TaskFactory`1.FromAsyncCoreLogic";
+        private const string IgnoreValueTaskGetResult = "System.Threading.Tasks.ValueTask`1.get_Result()";
+
+        private static readonly string[] Ignores = new string[] {
+            IgnoreTaskAwaiter,
+            IgnoreTaskContinuation,
+            IgnoreTaskExecute,
+            IgnoreTaskInnerInvoke,
+            IgnoreTaskGetResultCore,
+            IgnoreTaskGetResult,
+            IgnoreTaskFactory,
+            IgnoreValueTaskGetResult
+        };
+
+        private const string StackBreak = "--- End of stack trace from previous location where exception was thrown ---";
+        private const string NewStackBreak = "   :";
+
+        private static string Tidy(string stackTrace, int level = 0)
+        {
+            stackTrace = stackTrace.Replace(StackBreak, NewStackBreak);
+            var lines = stackTrace.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+            stackTrace = String.Join(Environment.NewLine, lines.Where(line => !Ignores.Any(ignore => line.Contains(ignore)))
+                                                               .Select(TidyLine)
+                                                               .Select(line => $"{new string(' ', level * 3)}{line}"));
+            return stackTrace;
+        }
+
+        private static readonly Regex removeSrcDir = new Regex(@"^(\s+at .* in )(.*[\\/]src[\\/])(.*)$");
+
+        private static string TidyLine(string line)
+        {
+            var match = removeSrcDir.Match(line);
+            if (match.Success)
+            {
+                return $"{match.Groups[1].Value}{match.Groups[3].Value}";
+            }
+            return line;
+        }
+    }
+}

--- a/src/Ensconce.Console/Program.cs
+++ b/src/Ensconce.Console/Program.cs
@@ -16,8 +16,7 @@ namespace Ensconce.Console
             }
             catch (Exception e)
             {
-                System.Console.Error.WriteLine("Something went wrong.");
-                System.Console.Error.WriteLine(e.ToString());
+                System.Console.Error.WriteLine(ExceptionDetails.GetDetails("Something went wrong.", e));
                 return -1;
             }
             finally

--- a/src/Ensconce.Console/TextRendering.cs
+++ b/src/Ensconce.Console/TextRendering.cs
@@ -6,7 +6,9 @@ namespace Ensconce.Console
 {
     internal static class TextRendering
     {
-        public static readonly Lazy<TagDictionary> TagDictionary = new Lazy<TagDictionary>(() => Retry.Do(BuildTagDictionary, TimeSpan.FromSeconds(5)));
+        public static readonly Lazy<TagDictionary> TagDictionary = new Lazy<TagDictionary>(() => Retry.Do(BuildTagDictionary,
+                                                                                                 TimeSpan.FromSeconds(5),
+                                                                                                 new[] { typeof(InvalidDataException) }));
 
         internal static string Render(this string s)
         {

--- a/src/Ensconce.Update.Tests/TagDictionaryTests.cs
+++ b/src/Ensconce.Update.Tests/TagDictionaryTests.cs
@@ -305,7 +305,8 @@ namespace Ensconce.Update.Tests
         {
             var sut = TagDictionary.FromSources("ident", new Dictionary<TagSource, string> { { TagSource.XmlData, XmlData } });
             var error = Assert.Throws<ArgumentException>(() => "{% for instance in GDS %}{% if instance.DbUser == \"true\" %}TextHere{% endif %}{% endfor %}".RenderTemplate(sut.ToLazyTagDictionary()));
-            Assert.AreEqual("Tag substitution errored on template string:\n{% for instance in GDS %}{% if instance.DbUser == \"true\" %}TextHere{% endif %}{% endfor %}\nObject must be of type String.", error.Message);
+            Assert.AreEqual("Tag substitution errored on template string:\n{% for instance in GDS %}{% if instance.DbUser == \"true\" %}TextHere{% endif %}{% endfor %}", error.Message);
+            Assert.AreEqual("Object must be of type String.", error.InnerException.Message);
         }
 
         [Test]

--- a/src/Ensconce.Update/NDjangoWrapper.cs
+++ b/src/Ensconce.Update/NDjangoWrapper.cs
@@ -85,7 +85,7 @@ namespace Ensconce.Update
                     values = new Lazy<TagDictionary>(TagDictionary.Empty);
                 }
 
-                string exceptionMessage = null;
+                Exception exception = null;
                 string replacementValue;
 
                 try
@@ -95,7 +95,7 @@ namespace Ensconce.Update
                 }
                 catch (Exception ex)
                 {
-                    exceptionMessage = $"\n{ex.Message}";
+                    exception = ex;
                     replacementValue = string.Empty;
                     Error.Invoked = true;
                 }
@@ -104,11 +104,11 @@ namespace Ensconce.Update
                 {
                     if (string.IsNullOrWhiteSpace(replacementValue) || !replacementValue.Contains(Error.ToString()))
                     {
-                        throw new ArgumentException(string.Format("Tag substitution errored on template string:\n{0}{1}", template, exceptionMessage));
+                        throw new ArgumentException($"Tag substitution errored on template string:\n{template}", exception);
                     }
 
                     var attemptedRender = replacementValue.Replace(Error.ToString(), "[ERROR OCCURRED HERE]");
-                    throw new ArgumentException(string.Format("Tag substitution failed on template string:\n{0}\n\nAttempted rendering was:\n{1}{2}", template, attemptedRender, exceptionMessage));
+                    throw new ArgumentException($"Tag substitution failed on template string:\n{template}\n\nAttempted rendering was:\n{attemptedRender}", exception);
                 }
 
                 return replacementValue;

--- a/src/Ensconce.Update/TagDictionary.cs
+++ b/src/Ensconce.Update/TagDictionary.cs
@@ -188,6 +188,8 @@ namespace Ensconce.Update
         {
             foreach (var propertyGroup in doc.XPathSelectElements("/Structure/PropertyGroups/PropertyGroup"))
             {
+                var identity = propertyGroup.Attribute("identity").Value;
+
                 var labels = new List<string>();
                 if (propertyGroup.Attribute("label") != null)
                 {
@@ -199,10 +201,9 @@ namespace Ensconce.Update
                 }
                 else
                 {
-                    throw new InvalidDataException("PropertyGroup found with no label attribute or nodes");
+                    throw new InvalidDataException($"PropertyGroup with identity '{identity}' has no label attribute or nodes");
                 }
 
-                var identity = propertyGroup.Attribute("identity").Value;
                 foreach (var label in labels)
                 {
                     SubTagDictionary labelDic;
@@ -211,7 +212,7 @@ namespace Ensconce.Update
                         labelDic = this[label] as SubTagDictionary;
                         if (labelDic == null)
                         {
-                            throw new InvalidDataException(string.Format("A label for a method group has been specified that clashes with a property name. The conflicting label is {0}", label));
+                            throw new InvalidDataException($"PropertyGroup with identity '{identity}' has a label specified that clashes with a property name. The conflicting label is {label}");
                         }
                     }
                     else


### PR DESCRIPTION
Changes error output from:

    Something went wrong. 
    System.ArgumentException: Tag substitution errored on template string: 
    {{ ClientCode }}-{{ Environment }}-Svc 
    One or more errors occurred. 
       at Ensconce.Update.NDjangoWrapper.Render(String template, Lazy`1 values, ITemplateManager templateManager) in E:\ba1\850655ce59456309\src\Ensconce.Update\NDjangoWrapper.cs:line 107 
       at Ensconce.Console.Program.MainLogic(String[] args) in E:\ba1\850655ce59456309\src\Ensconce.Console\Program.cs:line 55 
       at Ensconce.Console.Program.Main(String[] args) in E:\ba1\850655ce59456309\src\Ensconce.Console\Program.cs:line 14 



To:


    Something went wrong.

    >> InvalidDataException: PropertyGroup with identity 'AuntBetty' has no label attribute or nodes
    
       at Ensconce.Update.TagDictionary.LabelPropertiesFromXml(XDocument doc) in Ensconce.Update\TagDictionary.cs:line 204
       at Ensconce.Update.TagDictionary.PropertiesFromXml(String identifier, String xmlData) in Ensconce.Update\TagDictionary.cs:line 138
       at Ensconce.Update.TagDictionary.LoadDictionary(String identifier, Dictionary`2 sources) in Ensconce.Update\TagDictionary.cs:line 76
       at Ensconce.Update.TagDictionary.FromXml(String identifier, String xmlData) in Ensconce.Update\TagDictionary.cs:line 42
       at Ensconce.Console.TextRendering.BuildTagDictionary(String instanceName, String fixedPath, TagDictionary fallbackDictionary) in Ensconce.Console\TextRendering.cs:line 56
       at Ensconce.Console.TextRendering.BuildTagDictionary() in Ensconce.Console\TextRendering.cs:line 32
       at Ensconce.Console.Retry.Do[T](Func`1 action, TimeSpan retryInterval, Type[] doNotRetryTheseExceptions) in Ensconce.Console\Retry.cs:line 40
       at Ensconce.Console.TextRendering.<>c.<.cctor>b__5_0() in Ensconce.Console\TextRendering.cs:line 9
       at System.Lazy`1.CreateValue()
       at System.Lazy`1.LazyInitValue()
       at System.Lazy`1.get_Value()
       at Ensconce.Update.NDjangoWrapper.Render(String template, Lazy`1 values, ITemplateManager templateManager) in Ensconce.Update\NDjangoWrapper.cs:line 94
    
    >> ArgumentException: Tag substitution errored on template string:
    {{ ClientCode }}-{{ Environment }}-Svc
    
       at Ensconce.Update.NDjangoWrapper.Render(String template, Lazy`1 values, ITemplateManager templateManager) in Ensconce.Update\NDjangoWrapper.cs:line 107
       at Ensconce.Update.NDjangoWrapper.RenderTemplate(String template, Lazy`1 values) in Ensconce.Update\NDjangoWrapper.cs:line 69
       at Ensconce.Console.TextRendering.Render(String s) in Ensconce.Console\TextRendering.cs:line 15
       at Ensconce.Console.Program.MainLogic(String[] args) in Ensconce.Console\Program.cs:line 54
       at Ensconce.Console.Program.Main(String[] args) in Ensconce.Console\Program.cs:line 14