### PR TITLE
Catch "already killed" exceptions when calling Process.Kill

### DIFF
--- a/src/Ensconce.Console/ApplicationInteraction.cs
+++ b/src/Ensconce.Console/ApplicationInteraction.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -52,7 +54,19 @@ namespace Ensconce.Console
                 {
                     if (!string.IsNullOrEmpty(item.Path) && Path.GetFullPath(item.Path).Contains(new DirectoryInfo(directory).FullName))
                     {
-                        item.Process.Kill();
+                        const int Win32ErrorCodeAccessDenied = 5;
+                        try
+                        {
+                            item.Process.Kill();
+                        }
+                        catch (Win32Exception ex) when (ex.NativeErrorCode == Win32ErrorCodeAccessDenied)
+                        {
+                            // Process is already terminating.
+                        }
+                        catch (InvalidOperationException)
+                        {
+                            // Process has already terminated.
+                        }
                         item.Process.WaitForExit();
                     }
                 }


### PR DESCRIPTION
Prevents exceptions if the process is already terminating or terminated.

For testing:

```c#
var process = Process.Start("cmd");
process.Kill();
Thread.Sleep(1000); // Comment out delay to trigger terminating scenario, uncomment for terminated scenario.

const int Win32ErrorCodeAccessDenied = 5;
try
{
  process.Kill();
}
catch (Win32Exception ex) when (ex.NativeErrorCode == Win32ErrorCodeAccessDenied)
{
  // Process is already terminating.
  Console.WriteLine("terminating");
}
catch (InvalidOperationException)
{
  // Process has already terminated.
  Console.WriteLine("terminated");
}
process.WaitForExit();
Console.WriteLine("exited");
```