### PR TITLE
Add Support for setting an ip address when creating a new site or binding with IIS

### DIFF
--- a/docs/powershell/create-website/index.md
+++ b/docs/powershell/create-website/index.md
@@ -22,7 +22,9 @@ This section will detail the functions and which version of IIS the function is 
 ### IIS7 Only
 
 * AddAuthoringRule([string] $websiteName, [string] $userName, [string] $access)
-* CheckIfSslBindingExists([string]$webSite, [string]$hostHeader)
+* AddSslCertificate([string] $websiteName, [string] $friendlyName, [string] $hostHeader, [string] $ipAddress="*")
+* CheckIfSslBindingExists([string]$webSite, [string]$hostHeader, [string]$hostHeader, [string] $ipAddress="*")
+* CreateWebSite([string]$name, [string]$localPath, [string] $appPoolName, [string] $applicationName, [string] $hostName, [string] $logLocation, [int32] $port=80, [string] $ipAddress="*")
 * Enable32BitApps([string] $appPoolName)
 * EnableBasicAuthentication([string] $websiteName)
 * EnableParentPaths([string] $websiteName)

--- a/docs/powershell/create-website/index.md
+++ b/docs/powershell/create-website/index.md
@@ -18,6 +18,8 @@ This section will detail the functions and which version of IIS the function is 
 ### IIS6 Only
 
 * [AddWildcardMap [-websiteName] &lt;String&gt; [-subFolders]  &lt;String&gt;](add-wildcard-map)
+* AddSslCertificate([string] $websiteName, [string] $friendlyName, [string] $hostHeader)
+* CreateWebSite([string]$name, [string]$localPath, [string] $appPoolName, [string] $applicationName, [string] $hostName, [string] $logLocation, [int32] $port=80)
 
 ### IIS7 Only
 
@@ -40,14 +42,12 @@ This section will detail the functions and which version of IIS the function is 
 
 * AddDefaultDocument([string] $websiteName, [string] $defaultDocumentName)
 * AddHostHeader([string]$siteName, [string] $hostHeader, [int] $port, [string] $protocol)
-* AddSslCertificate([string] $websiteName, [string] $friendlyName, [string] $hostHeader)
 * CheckIfAppPoolExists([string]$name)
 * CheckIfVirtualDirectoryExists([string]$webSite, [string]$virtualDir)
 * CheckIfWebApplicationExists([string]$webSite, [string]$appName)
 * CheckIfWebSiteExists([string]$name)
 * CreateAppPool([string]$name)
 * CreateWebApplication([string]$webSite, [string]$appName, [string] $appPool, [string]$InstallDir, [string]$SubFolders)
-* CreateWebSite([string]$name, [string]$localPath, [string] $appPoolName, [string] $applicationName, [string] $hostName, [string] $logLocation, [int32] $port=80)
 * CreateVirtualDirectory([string]$webSite, [string]$virtualDir, [string]$physicalPath)
 * DefaultApplicationPoolGroup()
 * RestartAppPool([string]$name)

--- a/src/Scripts/createiis7app.ps1
+++ b/src/Scripts/createiis7app.ps1
@@ -329,7 +329,7 @@ function CreateVirtualDirectory([string]$webSite, [string]$virtualDir, [string]$
 	New-WebVirtualDirectory -Site $webSite -Name $virtualDir -PhysicalPath $physicalPath
 }
 
-function AddSslCertificate ([string] $websiteName, [string] $friendlyName, [string] $hostHeader,, [string] $ipAddress)
+function AddSslCertificate ([string] $websiteName, [string] $friendlyName, [string] $hostHeader, [string] $ipAddress)
 {
 	# accounts for possible empty strings
 	if(!$ipAddress)

--- a/src/Scripts/createiis7app.ps1
+++ b/src/Scripts/createiis7app.ps1
@@ -198,9 +198,9 @@ function CheckIfVirtualDirectoryExists ([string]$webSite, [string]$virtualDir)
 	$tempApp -ne $NULL
 }
 
-function CheckIfSslBindingExists ([string]$webSite, [string]$hostHeader)
+function CheckIfSslBindingExists ([string]$webSite, [string]$hostHeader, [string] $ipAddress="*")
 {
-	$tempApp = Get-WebBinding -Name $webSite -HostHeader $hostHeader -Protocol https
+	$tempApp = Get-WebBinding -Name $webSite -IPAddress $ipAddress -HostHeader $hostHeader -Protocol https
 	$tempApp -ne $NULL
 }
 
@@ -251,32 +251,44 @@ function SetAppPoolIdentity([string]$name, [string]$user, [string]$password)
 	$appPool | set-item
 }
 
-function CreateWebSite ([string]$name, [string]$localPath, [string] $appPoolName, [string] $applicationName, [string] $hostName, [string] $logLocation, [int32] $port=80)
+function CreateWebSite ([string]$name, [string]$localPath, [string] $appPoolName, [string] $applicationName, [string] $hostName, [string] $logLocation, [int32] $port=80, [string] $ipAddress="*")
 {
+	# accounts for possible empty strings
+	if(!$ipAddress)
+    {
+        $ipAddress = "*"
+    }
+
 	$site = Get-WebSite | where { $_.Name -eq $name }
 	if($site -eq $null)
 	{
 		EnsurePath $localPath
 		if ($port -eq 443) {
-			New-WebSite $name -Port $port -HostHeader $hostName -PhysicalPath $localPath -ApplicationPool $appPoolName -ssl
+			New-WebSite $name -IPAddress $ipAddress -Port $port -HostHeader $hostName -PhysicalPath $localPath -ApplicationPool $appPoolName -ssl
 		} else {
-			New-WebSite $name -Port $port -HostHeader $hostName -PhysicalPath $localPath -ApplicationPool $appPoolName
+			New-WebSite $name -IPAddress $ipAddress -Port $port -HostHeader $hostName -PhysicalPath $localPath -ApplicationPool $appPoolName
 		}
 	}
 
 	Set-ItemProperty IIS:\Sites\$name -name logFile.directory -value $logLocation
 }
 
-function AddHostHeader([string]$siteName, [string] $hostHeader, [int] $port, [string] $protocol)
+function AddHostHeader([string]$siteName, [string] $hostHeader, [int] $port, [string] $protocol, [string] $ipAddress="*")
 {
 	if($protocol -eq "" ) {
 		$protocol = "http"
 	}
+	
+	# accounts for possible empty strings
+	if(!$ipAddress)
+    {
+        $ipAddress = "*"
+    }
 
 	$site = Get-WebSite | where { $_.Name -eq $siteName }
 	if($site -ne $null)
 	{
-		$webBinding = Get-WebBinding -Name $siteName -IPAddress "*" -Port $port -HostHeader $hostHeader -Protocol $protocol
+		$webBinding = Get-WebBinding -Name $siteName -IPAddress $ipAddress -Port $port -HostHeader $hostHeader -Protocol $protocol
 		if($webBinding -eq $null) {
 			if( $hostHeader -eq "" ) {
 				"Host-header is empty, cannot add" | Write-Host
@@ -285,7 +297,7 @@ function AddHostHeader([string]$siteName, [string] $hostHeader, [int] $port, [st
 				$supportedProtocols = "http", "https", "net.tcp", "net.pipe", "net.msmq", "msmq.formatname"
 				if($supportedProtocols -contains $protocol) {
 					"Adding additional host-header binding of: $hostHeader, port: $port, protocol: $protocol" | Write-Host
-					New-WebBinding -Name $siteName -IPAddress "*" -Port $port -HostHeader $hostHeader -Protocol $protocol
+					New-WebBinding -Name $siteName -IPAddress $ipAddress -Port $port -HostHeader $hostHeader -Protocol $protocol
 				}
 				else {
 					"Error - cant add binding, protocol: $protocol is not supported in IIS7" | Write-Host
@@ -317,11 +329,17 @@ function CreateVirtualDirectory([string]$webSite, [string]$virtualDir, [string]$
 	New-WebVirtualDirectory -Site $webSite -Name $virtualDir -PhysicalPath $physicalPath
 }
 
-function AddSslCertificate ([string] $websiteName, [string] $friendlyName, [string] $hostHeader)
+function AddSslCertificate ([string] $websiteName, [string] $friendlyName, [string] $hostHeader,, [string] $ipAddress)
 {
+	# accounts for possible empty strings
+	if(!$ipAddress)
+    {
+        $ipAddress = "*"
+    }
+
 	$checkBinding = CheckIfSslBindingExists $instanceName $hostHeader
 	if ( $checkBinding -eq $False) {
-		New-WebBinding -Name $websiteName -IP "*" -Port 443 -Protocol https -HostHeader $hostHeader
+		New-WebBinding -Name $websiteName -IP $ipAddress -Port 443 -Protocol https -HostHeader $hostHeader
 	}
 
 	try


### PR DESCRIPTION
Updates the the IIS7 website deployments to support the setting of an ip address when creating a new website or setting the SSL certificate and binding.

This is required if you wish to have multiple ssl certificates on windows server 2008 as it does not support multiple ssl certs on the same ip address.

Updates made to the following methods
CheckIfSslBindingExists - Adds checking of the ip address (default = "*")
CreateWebSite - adds optional ipAddress parameter (default = "*")
AddSslCertificate - adds optional ipAddress parameter (default = "*")