### PR TITLE
Update emailBodyText in subinfo to not be required

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -6,7 +6,7 @@ using System.Text.RegularExpressions;
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Release");
 
-var baseVersion = "1.7.2";
+var baseVersion = "1.7.3";
 var subVersion = "";
 var subVersionNumber = "";
 var isMasterOrDevelop = false;

--- a/src/Ensconce.ReportingServices/SubscriptionInfoFileLoader.cs
+++ b/src/Ensconce.ReportingServices/SubscriptionInfoFileLoader.cs
@@ -151,7 +151,7 @@ namespace Ensconce.ReportingServices
                     extensionParams[7] = new ParameterValue
                     {
                         Name = "Comment",
-                        Value = GetSubInfoValue(subscriptionInfoText, "emailBodyText", true)
+                        Value = GetSubInfoValue(subscriptionInfoText, "emailBodyText", false)
                     };
                     extensionParams[8] = new ParameterValue { Name = "IncludeLink", Value = "False" };
                     extensionParams[9] = new ParameterValue { Name = "Priority", Value = "NORMAL" };


### PR DESCRIPTION
This was not required in 1.6.x