### PR TITLE
Update to DNS Helper to handle different TTL values

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -6,7 +6,7 @@ using System.Text.RegularExpressions;
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Release");
 
-var baseVersion = "1.7.3";
+var baseVersion = "1.7.4";
 var subVersion = "";
 var subVersionNumber = "";
 var isMasterOrDevelop = false;

--- a/src/Scripts/dnsHelper.ps1
+++ b/src/Scripts/dnsHelper.ps1
@@ -114,14 +114,15 @@ function CreateCName ([string]$dnsServer, [string]$domain, [string]$name, [strin
 
 function UpdateCName ([string]$dnsServer, [string]$domain, [string]$name, [string]$server)
 {
-    $currentRecord = (GetDnsRecords $dnsServer $domain $name | Where-Object {$_.Record -eq $name.ToLower()})
-    $currentTtl = ($currentRecord | Select-Object -ExpandProperty Ttl -First 1)
-    $currentType = ($currentRecord | Select-Object -ExpandProperty Type -First 1)
-    if($currentType -eq "CNAME")
+    $currentRecords = (GetDnsRecords $dnsServer $domain $name | Where-Object {$_.Record -eq $name.ToLower()})
+    $currentTtl = ($currentRecords | Select-Object -ExpandProperty Ttl -First 1)
+    $currentHasA =  ($dnsRecords | Where-Object {$_.Type -eq "A"} | measure).Count -ge 1
+    $currentHasCNAME =  ($dnsRecords | Where-Object {$_.Type -eq "CNAME"} | measure).Count -ge 1
+    if($currentHasCNAME -eq $true)
     {
         DeleteCName $dnsServer $domain $name
     }
-    if($currentType -eq "A")
+    if($currentHasA -eq $true)
     {
         DeleteARecord $dnsServer $domain $name
     }
@@ -232,14 +233,15 @@ function CreateARecord ([string]$dnsServer, [string]$domain, [string]$name, [str
 
 function UpdateARecord ([string]$dnsServer, [string]$domain, [string]$name, [string]$ipAddress)
 {
-    $currentRecord = (GetDnsRecords $dnsServer $domain $name | Where-Object {$_.Record -eq $name.ToLower()})
-    $currentTtl = ($currentRecord | Select-Object -ExpandProperty Ttl -First 1)
-    $currentType = ($currentRecord | Select-Object -ExpandProperty Type -First 1)
-    if($currentType -eq "CNAME")
+    $currentRecords = (GetDnsRecords $dnsServer $domain $name | Where-Object {$_.Record -eq $name.ToLower()})
+    $currentTtl = ($currentRecords | Select-Object -ExpandProperty Ttl -First 1)
+    $currentHasA =  ($dnsRecords | Where-Object {$_.Type -eq "A"} | measure).Count -ge 1
+    $currentHasCNAME =  ($dnsRecords | Where-Object {$_.Type -eq "CNAME"} | measure).Count -ge 1
+    if($currentHasCNAME -eq $true)
     {
         DeleteCName $dnsServer $domain $name
     }
-    if($currentType -eq "A")
+    if($currentHasA -eq $true)
     {
         DeleteARecord $dnsServer $domain $name
     }

--- a/src/Scripts/dnsHelper.ps1
+++ b/src/Scripts/dnsHelper.ps1
@@ -12,16 +12,16 @@ function GetDnsRecords ([string]$dnsServer, [string]$domain, [string]$lookupName
         {
             $key = $match.Groups["key"].Value
             $ttl = $match.Groups["ttl"].Value
-            $type = $match.Groups["type"].Value
-            $value = $match.Groups["value"].Value
+            $type = $match.Groups["type"].Value.ToUpper()
+            $value = $match.Groups["value"].Value.ToLower()
 
             if($key -eq "@")
             {
-                $record = $lookupName
+                $record = "$lookupName".ToLower()
             }
             else
             {
-                $record = "$key.$lookupName"
+                $record = "$key.$lookupName".ToLower()
             }
 
             if($value.EndsWith("."))
@@ -45,7 +45,7 @@ function GetAllSubValues ([string]$dnsServer, [string]$domain, [string]$lookupNa
 function CheckName ([string]$dnsServer, [string]$domain, [string]$lookupName)
 {
     $dnsRecords = GetDnsRecords $dnsServer $domain $lookupName
-    $checkResult = ($dnsRecords | Where-Object {$_.Record -eq $lookupName} | measure).Count -eq 1
+    $checkResult = ($dnsRecords | Where-Object {$_.Record -eq $lookupName.ToLower()} | measure).Count -eq 1
 
     if($checkResult -eq $false)
     {
@@ -59,7 +59,7 @@ function CheckName ([string]$dnsServer, [string]$domain, [string]$lookupName)
 function CheckCNameValue ([string]$dnsServer, [string]$domain, [string]$name, [string]$server)
 {
     $dnsRecords = GetDnsRecords $dnsServer $domain $name
-    $checkResult = ($dnsRecords | Where-Object {$_.Record -eq $name -and $_.Type -eq "CNAME" -and $_.Value -eq $server} | measure).Count -eq 1
+    $checkResult = ($dnsRecords | Where-Object {$_.Record -eq $name.ToLower() -and $_.Type -eq "CNAME" -and $_.Value -eq $server.ToLower()} | measure).Count -eq 1
 
     if($checkResult -eq $false)
     {
@@ -114,7 +114,7 @@ function CreateCName ([string]$dnsServer, [string]$domain, [string]$name, [strin
 
 function UpdateCName ([string]$dnsServer, [string]$domain, [string]$name, [string]$server)
 {
-    $currentRecord = (GetDnsRecords $dnsServer $domain $name | Where-Object {$_.Record -eq $name})
+    $currentRecord = (GetDnsRecords $dnsServer $domain $name | Where-Object {$_.Record -eq $name.ToLower()})
     $currentTtl = ($currentRecord | Select-Object -ExpandProperty Ttl -First 1)
     $currentType = ($currentRecord | Select-Object -ExpandProperty Type -First 1)
     if($currentType -eq "CNAME")
@@ -177,7 +177,7 @@ function CreateOrUpdateCName ([string]$dnsServer, [string]$domain, [string]$name
 function CheckARecordValue ([string]$dnsServer, [string]$domain, [string]$name, [string]$ipAddress)
 {
     $dnsRecords = GetDnsRecords $dnsServer $domain $name
-    $checkResult = ($dnsRecords | Where-Object {$_.Record -eq $name -and $_.Type -eq "A" -and $_.Value -eq $ipAddress} | measure).Count -eq 1
+    $checkResult = ($dnsRecords | Where-Object {$_.Record -eq $name.ToLower() -and $_.Type -eq "A" -and $_.Value -eq $ipAddress} | measure).Count -eq 1
 
     if($checkResult -eq $false)
     {
@@ -232,7 +232,7 @@ function CreateARecord ([string]$dnsServer, [string]$domain, [string]$name, [str
 
 function UpdateARecord ([string]$dnsServer, [string]$domain, [string]$name, [string]$ipAddress)
 {
-    $currentRecord = (GetDnsRecords $dnsServer $domain $name | Where-Object {$_.Record -eq $name})
+    $currentRecord = (GetDnsRecords $dnsServer $domain $name | Where-Object {$_.Record -eq $name.ToLower()})
     $currentTtl = ($currentRecord | Select-Object -ExpandProperty Ttl -First 1)
     $currentType = ($currentRecord | Select-Object -ExpandProperty Type -First 1)
     if($currentType -eq "CNAME")

--- a/src/Scripts/dnsHelper.ps1
+++ b/src/Scripts/dnsHelper.ps1
@@ -45,7 +45,7 @@ function GetAllSubValues ([string]$dnsServer, [string]$domain, [string]$lookupNa
 function CheckName ([string]$dnsServer, [string]$domain, [string]$lookupName)
 {
     $dnsRecords = GetDnsRecords $dnsServer $domain $lookupName
-    $checkResult = ($dnsRecords | Where-Object {$_.Record -eq $lookupName.ToLower()} | measure).Count -eq 1
+    $checkResult = ($dnsRecords | Where-Object {$_.Record -eq $lookupName.ToLower()} | measure).Count -ge 1
 
     if($checkResult -eq $false)
     {
@@ -59,7 +59,7 @@ function CheckName ([string]$dnsServer, [string]$domain, [string]$lookupName)
 function CheckCNameValue ([string]$dnsServer, [string]$domain, [string]$name, [string]$server)
 {
     $dnsRecords = GetDnsRecords $dnsServer $domain $name
-    $checkResult = ($dnsRecords | Where-Object {$_.Record -eq $name.ToLower() -and $_.Type -eq "CNAME" -and $_.Value -eq $server.ToLower()} | measure).Count -eq 1
+    $checkResult = ($dnsRecords | Where-Object {$_.Record -eq $name.ToLower() -and $_.Type -eq "CNAME" -and $_.Value -eq $server.ToLower()} | measure).Count -ge 1
 
     if($checkResult -eq $false)
     {
@@ -177,7 +177,7 @@ function CreateOrUpdateCName ([string]$dnsServer, [string]$domain, [string]$name
 function CheckARecordValue ([string]$dnsServer, [string]$domain, [string]$name, [string]$ipAddress)
 {
     $dnsRecords = GetDnsRecords $dnsServer $domain $name
-    $checkResult = ($dnsRecords | Where-Object {$_.Record -eq $name.ToLower() -and $_.Type -eq "A" -and $_.Value -eq $ipAddress} | measure).Count -eq 1
+    $checkResult = ($dnsRecords | Where-Object {$_.Record -eq $name.ToLower() -and $_.Type -eq "A" -and $_.Value -eq $ipAddress} | measure).Count -ge 1
 
     if($checkResult -eq $false)
     {

--- a/src/Scripts/dnsHelper.ps1
+++ b/src/Scripts/dnsHelper.ps1
@@ -1,68 +1,73 @@
 Write-Host "Ensconce - dnsHelper Loading"
 
-function GetAllSubValues ([string]$dnsServer, [string]$domain, [string]$lookupName)
+function GetDnsRecords ([string]$dnsServer, [string]$domain, [string]$lookupName)
 {
     $result = dnscmd $dnsServer /EnumRecords $domain $lookupName
 
-    $keys = New-Object Collections.Generic.List[string]
+    $keys = New-Object Collections.Generic.List[pscustomobject]
     foreach ($item in $result)
     {
-        if ($item.Contains("3600 CNAME") -or ($item.Contains("3600 A")))
+        $match = [regex]::Match($item, "^(?<key>\S*)\s+(?<ttl>\d+)\s+(?<type>\S+)\s+(?<value>.+)$")
+        if($match.Success)
         {
-            $key = $item -replace "\s*3600.*", ""
+            $key = $match.Groups["key"].Value
+            $ttl = $match.Groups["ttl"].Value
+            $type = $match.Groups["type"].Value
+            $value = $match.Groups["value"].Value
+
             if($key -eq "@")
             {
-                $keys.Add("$lookupName".ToLower())
+                $record = $lookupName
             }
             else
             {
-                $keys.Add("$key.$lookupName".ToLower())
+                $record = "$key.$lookupName"
             }
+
+            if($value.EndsWith("."))
+            {
+                $value = $value.Substring(0,$value.Length-1)
+            }
+
+            $keys.Add([pscustomobject]@{Record=$record;Ttl=$ttl;Type=$type;Value=$value})
         }
+
     }
 
     $keys
 }
 
+function GetAllSubValues ([string]$dnsServer, [string]$domain, [string]$lookupName)
+{
+    GetDnsRecords $dnsServer $domain $lookupName | Select -ExpandProperty Record
+}
+
 function CheckName ([string]$dnsServer, [string]$domain, [string]$lookupName)
 {
-    $result = dnscmd $dnsServer /EnumRecords $domain $lookupName /node
-    $outcome = $False
-    foreach ($item in $result)
+    $dnsRecords = GetDnsRecords $dnsServer $domain $lookupName
+    $checkResult = ($dnsRecords | Where-Object {$_.Record -eq $lookupName} | measure).Count -eq 1
+
+    if($checkResult -eq $false)
     {
-        if ($item.Contains("3600 CNAME") -or ($item.Contains("3600 A")))
-        {
-            $outcome = $True
-        }
+        Write-Host "CheckName is false records found:"
+        Write-Host ($dnsRecords | Out-String)
     }
 
-    if($outcome -eq $false)
-    {
-        write-host "dnscmd: $result"
-    }
-
-    $outcome
+    $checkResult
 }
 
 function CheckCNameValue ([string]$dnsServer, [string]$domain, [string]$name, [string]$server)
 {
-    $result = dnscmd $dnsServer /EnumRecords $domain $name /node
+    $dnsRecords = GetDnsRecords $dnsServer $domain $name
+    $checkResult = ($dnsRecords | Where-Object {$_.Record -eq $name -and $_.Type -eq "CNAME" -and $_.Value -eq $server} | measure).Count -eq 1
 
-    $outcome = $False
-    foreach ($item in $result)
+    if($checkResult -eq $false)
     {
-        if ($item.Contains("3600 CNAME") -and ($item.ToLower().Contains($server.ToLower())))
-        {
-            $outcome = $True
-        }
+        Write-Host "CheckCNameValue is false records found:"
+        Write-Host ($dnsRecords | Out-String)
     }
 
-    if($outcome -eq $false)
-    {
-        write-host "dnscmd: $result"
-    }
-
-    $outcome
+    $checkResult
 }
 
 function DeleteCName ([string]$dnsServer, [string]$domain, [string]$name)
@@ -86,10 +91,10 @@ function DeleteCName ([string]$dnsServer, [string]$domain, [string]$name)
     $outcome
 }
 
-function CreateCName ([string]$dnsServer, [string]$domain, [string]$name, [string]$server)
+function CreateCName ([string]$dnsServer, [string]$domain, [string]$name, [string]$server, [string]$ttl="3600")
 {
-    write-host "Creating DNS CNAME record for $name.$domain pointing at $server"
-    $result = dnscmd $dnsServer /recordAdd $domain $name CNAME $server
+    write-host "Creating DNS CNAME record for $name.$domain pointing at $server with TTL $ttl"
+    $result = dnscmd $dnsServer /recordAdd $domain $name $ttl CNAME $server
     $outcome = $false
     foreach ($item in $result)
     {
@@ -109,9 +114,18 @@ function CreateCName ([string]$dnsServer, [string]$domain, [string]$name, [strin
 
 function UpdateCName ([string]$dnsServer, [string]$domain, [string]$name, [string]$server)
 {
-    DeleteCName $dnsServer $domain $name
-    DeleteARecord $dnsServer $domain $name
-    CreateCName $dnsServer $domain $name $server
+    $currentRecord = (GetDnsRecords $dnsServer $domain $name | Where-Object {$_.Record -eq $name})
+    $currentTtl = ($currentRecord | Select-Object -ExpandProperty Ttl -First 1)
+    $currentType = ($currentRecord | Select-Object -ExpandProperty Type -First 1)
+    if($currentType -eq "CNAME")
+    {
+        DeleteCName $dnsServer $domain $name
+    }
+    if($currentType -eq "A")
+    {
+        DeleteARecord $dnsServer $domain $name
+    }
+    CreateCName $dnsServer $domain $name $server $currentTtl
 }
 
 function CreateOrUpdateCName ([string]$dnsServer, [string]$domain, [string]$name, [string]$server, [bool]$warnOnUpdate = $false)
@@ -162,22 +176,16 @@ function CreateOrUpdateCName ([string]$dnsServer, [string]$domain, [string]$name
 
 function CheckARecordValue ([string]$dnsServer, [string]$domain, [string]$name, [string]$ipAddress)
 {
-    $result = dnscmd $dnsServer /EnumRecords $domain $name /node
-    $outcome = $False
-    foreach ($item in $result)
+    $dnsRecords = GetDnsRecords $dnsServer $domain $name
+    $checkResult = ($dnsRecords | Where-Object {$_.Record -eq $name -and $_.Type -eq "A" -and $_.Value -eq $ipAddress} | measure).Count -eq 1
+
+    if($checkResult -eq $false)
     {
-        if ($item.Contains("3600 A") -and ($item.Contains($ipAddress)))
-        {
-            $outcome = $True
-        }
+        Write-Host "CheckARecordValue is false records found:"
+        Write-Host ($dnsRecords | Out-String)
     }
 
-    if($outcome -eq $false)
-    {
-        write-host "dnscmd: $result"
-    }
-
-    $outcome
+    $checkResult
 }
 
 function DeleteARecord ([string]$dnsServer, [string]$domain, [string]$name)
@@ -201,9 +209,9 @@ function DeleteARecord ([string]$dnsServer, [string]$domain, [string]$name)
     $outcome
 }
 
-function CreateARecord ([string]$dnsServer, [string]$domain, [string]$name, [string]$ipAddress)
+function CreateARecord ([string]$dnsServer, [string]$domain, [string]$name, [string]$ipAddress, [string]$ttl="3600")
 {
-    write-host "Creating DNS A record for $name.$domain pointing at $ipAddress"
+    write-host "Creating DNS A record for $name.$domain pointing at $ipAddress with TTL $ttl"
     $result = dnscmd $dnsServer /recordAdd $domain $name A $ipAddress
     $outcome = $false
     foreach ($item in $result)
@@ -224,9 +232,18 @@ function CreateARecord ([string]$dnsServer, [string]$domain, [string]$name, [str
 
 function UpdateARecord ([string]$dnsServer, [string]$domain, [string]$name, [string]$ipAddress)
 {
-    DeleteCName $dnsServer $domain $name
-    DeleteARecord $dnsServer $domain $name
-    CreateARecord $dnsServer $domain $name $ipAddress
+    $currentRecord = (GetDnsRecords $dnsServer $domain $name | Where-Object {$_.Record -eq $name})
+    $currentTtl = ($currentRecord | Select-Object -ExpandProperty Ttl -First 1)
+    $currentType = ($currentRecord | Select-Object -ExpandProperty Type -First 1)
+    if($currentType -eq "CNAME")
+    {
+        DeleteCName $dnsServer $domain $name
+    }
+    if($currentType -eq "A")
+    {
+        DeleteARecord $dnsServer $domain $name
+    }
+    CreateARecord $dnsServer $domain $name $ipAddress $currentTtl
 }
 
 function CreateOrUpdateARecord ([string]$dnsServer, [string]$domain, [string]$name, [string]$ipAddress, [bool]$warnOnUpdate = $false)

--- a/src/Scripts/dnsHelper.ps1
+++ b/src/Scripts/dnsHelper.ps1
@@ -31,7 +31,6 @@ function GetDnsRecords ([string]$dnsServer, [string]$domain, [string]$lookupName
 
             $keys.Add([pscustomobject]@{Record=$record;Ttl=$ttl;Type=$type;Value=$value})
         }
-
     }
 
     $keys
@@ -49,8 +48,8 @@ function CheckName ([string]$dnsServer, [string]$domain, [string]$lookupName)
 
     if($checkResult -eq $false)
     {
-        Write-Host "CheckName is false records found:"
-        Write-Host ($dnsRecords | Out-String)
+        Write-Host "$dnsServer : CheckName for $lookupName.$domain is false records found:"
+        $dnsRecords  | Format-Table | Out-String |% { Write-Host $_.Trim() }
     }
 
     $checkResult
@@ -63,8 +62,8 @@ function CheckCNameValue ([string]$dnsServer, [string]$domain, [string]$name, [s
 
     if($checkResult -eq $false)
     {
-        Write-Host "CheckCNameValue is false records found:"
-        Write-Host ($dnsRecords | Out-String)
+        Write-Host "$dnsServer : CheckCNameValue for $lookupName.$domain value $server is false records found:"
+        $dnsRecords  | Format-Table | Out-String |% { Write-Host $_.Trim() }
     }
 
     $checkResult
@@ -72,7 +71,7 @@ function CheckCNameValue ([string]$dnsServer, [string]$domain, [string]$name, [s
 
 function DeleteCName ([string]$dnsServer, [string]$domain, [string]$name)
 {
-    write-host "Deleting DNS CNAME records for $name.$domain"
+    write-host "$dnsServer : Deleting DNS CNAME records for $name.$domain"
     $result = dnscmd $dnsServer /recordDelete $domain $name CNAME /f
     $outcome = $false
     foreach ($item in $result)
@@ -85,7 +84,7 @@ function DeleteCName ([string]$dnsServer, [string]$domain, [string]$name)
 
     if($outcome -eq $false)
     {
-        write-host "dnscmd: $result"
+        write-host "$dnsServer : $result"
     }
 
     $outcome
@@ -93,7 +92,7 @@ function DeleteCName ([string]$dnsServer, [string]$domain, [string]$name)
 
 function CreateCName ([string]$dnsServer, [string]$domain, [string]$name, [string]$server, [string]$ttl="3600")
 {
-    write-host "Creating DNS CNAME record for $name.$domain pointing at $server with TTL $ttl"
+    write-host "$dnsServer : Creating DNS CNAME record for $name.$domain pointing at $server with TTL $ttl"
     $result = dnscmd $dnsServer /recordAdd $domain $name $ttl CNAME $server
     $outcome = $false
     foreach ($item in $result)
@@ -106,7 +105,7 @@ function CreateCName ([string]$dnsServer, [string]$domain, [string]$name, [strin
 
     if($outcome -eq $false)
     {
-        write-host "dnscmd: $result"
+        write-host "$dnsServer : $result"
     }
 
     $outcome
@@ -136,7 +135,7 @@ function CreateOrUpdateCName ([string]$dnsServer, [string]$domain, [string]$name
     {
         if(CheckCNameValue $dnsServer $domain $name $server)
         {
-            write-host "DNS CNAME record for $name.$domain already pointing at $server"
+            write-host "$dnsServer : DNS CNAME record for $name.$domain already pointing at $server"
             $outcome = $true
         }
         else
@@ -146,16 +145,16 @@ function CreateOrUpdateCName ([string]$dnsServer, [string]$domain, [string]$name
                 $outcome = $true
                 if($warnOnUpdate)
                 {
-                    write-warning "DNS CNAME record for $name.$domain updated to point at $server"
+                    write-warning "$dnsServer : DNS CNAME record for $name.$domain updated to point at $server"
                 }
                 else
                 {
-                    write-host "DNS CNAME record for $name.$domain updated to point at $server"
+                    write-host "$dnsServer : DNS CNAME record for $name.$domain updated to point at $server"
                 }
             }
             else
             {
-                write-error "Failed to update DNS CNAME record for $name.$domain"
+                write-error "$dnsServer : Failed to update DNS CNAME record for $name.$domain"
             }
         }
     }
@@ -164,11 +163,11 @@ function CreateOrUpdateCName ([string]$dnsServer, [string]$domain, [string]$name
         if(CreateCName $dnsServer $domain $name $server)
         {
             $outcome = $true
-            write-host "DNS CNAME record for $name.$domain created pointing at $server"
+            write-host "$dnsServer : DNS CNAME record for $name.$domain created pointing at $server"
         }
         else
         {
-            write-error "Failed to create DNS CNAME record for $name.$domain"
+            write-error "$dnsServer : Failed to create DNS CNAME record for $name.$domain"
         }
     }
 
@@ -182,8 +181,8 @@ function CheckARecordValue ([string]$dnsServer, [string]$domain, [string]$name, 
 
     if($checkResult -eq $false)
     {
-        Write-Host "CheckARecordValue is false records found:"
-        Write-Host ($dnsRecords | Out-String)
+        Write-Host "$dnsServer : CheckARecordValue for $lookupName.$domain value $ipAddress is false records found:"
+        $dnsRecords  | Format-Table | Out-String |% { Write-Host $_.Trim() }
     }
 
     $checkResult
@@ -191,7 +190,7 @@ function CheckARecordValue ([string]$dnsServer, [string]$domain, [string]$name, 
 
 function DeleteARecord ([string]$dnsServer, [string]$domain, [string]$name)
 {
-    write-host "Deleting DNS A records for $name.$domain"
+    write-host "$dnsServer : Deleting DNS A records for $name.$domain"
     $result = dnscmd $dnsServer /recordDelete $domain $name A /f
     $outcome = $false
     foreach ($item in $result)
@@ -204,7 +203,7 @@ function DeleteARecord ([string]$dnsServer, [string]$domain, [string]$name)
 
     if($outcome -eq $false)
     {
-        write-host "dnscmd: $result"
+        write-host "$dnsServer : $result"
     }
 
     $outcome
@@ -212,7 +211,7 @@ function DeleteARecord ([string]$dnsServer, [string]$domain, [string]$name)
 
 function CreateARecord ([string]$dnsServer, [string]$domain, [string]$name, [string]$ipAddress, [string]$ttl="3600")
 {
-    write-host "Creating DNS A record for $name.$domain pointing at $ipAddress with TTL $ttl"
+    write-host "$dnsServer : Creating DNS A record for $name.$domain pointing at $ipAddress with TTL $ttl"
     $result = dnscmd $dnsServer /recordAdd $domain $name $ttl A $ipAddress
     $outcome = $false
     foreach ($item in $result)
@@ -225,7 +224,7 @@ function CreateARecord ([string]$dnsServer, [string]$domain, [string]$name, [str
 
     if($outcome -eq $false)
     {
-        write-host "dnscmd: $result"
+        write-host "$dnsServer : $result"
     }
 
     $outcome
@@ -255,7 +254,7 @@ function CreateOrUpdateARecord ([string]$dnsServer, [string]$domain, [string]$na
     {
         if(CheckARecordValue $dnsServer $domain $name $ipAddress)
         {
-            write-host "DNS A record for $name.$domain already pointing at $ipAddress"
+            write-host "$dnsServer : DNS A record for $name.$domain already pointing at $ipAddress"
             $outcome = $true
         }
         else
@@ -265,16 +264,16 @@ function CreateOrUpdateARecord ([string]$dnsServer, [string]$domain, [string]$na
                 $outcome = $true
                 if($warnOnUpdate)
                 {
-                    write-warning "DNS A record for $name.$domain updated to point at $ipAddress"
+                    write-warning "$dnsServer : DNS A record for $name.$domain updated to point at $ipAddress"
                 }
                 else
                 {
-                    write-host "DNS A record for $name.$domain updated to point at $ipAddress"
+                    write-host "$dnsServer : DNS A record for $name.$domain updated to point at $ipAddress"
                 }
             }
             else
             {
-                write-error "Failed to update DNS A record for $name.$domain"
+                write-error "$dnsServer : Failed to update DNS A record for $name.$domain"
             }
         }
     }
@@ -283,11 +282,11 @@ function CreateOrUpdateARecord ([string]$dnsServer, [string]$domain, [string]$na
         if(CreateARecord $dnsServer $domain $name $ipAddress)
         {
             $outcome = $true
-            write-host "DNS A record for $name.$domain created pointing at $ipAddress"
+            write-host "$dnsServer : DNS A record for $name.$domain created pointing at $ipAddress"
         }
         else
         {
-            write-error "Failed to create DNS A record for $name.$domain"
+            write-error "$dnsServer : Failed to create DNS A record for $name.$domain"
         }
     }
     $outcome
@@ -318,16 +317,16 @@ function DeleteDns([string]$dnsServer, [string]$domain, [string]$name, [bool]$wa
             $outcome = $true
             if($warnOnUpdate)
             {
-                write-warning "DNS A record for $name.$domain has been removed"
+                write-warning "$dnsServer : DNS A record for $name.$domain has been removed"
             }
             else
             {
-                write-host "DNS A record for $name.$domain has been removed"
+                write-host "$dnsServer : DNS A record for $name.$domain has been removed"
             }
         }
         else
         {
-            write-error "Failed to remove DNS A record for $name.$domain"
+            write-error "$dnsServer : Failed to remove DNS A record for $name.$domain"
         }
     }
     $outcome

--- a/src/Scripts/dnsHelper.ps1
+++ b/src/Scripts/dnsHelper.ps1
@@ -116,8 +116,8 @@ function UpdateCName ([string]$dnsServer, [string]$domain, [string]$name, [strin
 {
     $currentRecords = (GetDnsRecords $dnsServer $domain $name | Where-Object {$_.Record -eq $name.ToLower()})
     $currentTtl = ($currentRecords | Select-Object -ExpandProperty Ttl -First 1)
-    $currentHasA =  ($dnsRecords | Where-Object {$_.Type -eq "A"} | measure).Count -ge 1
-    $currentHasCNAME =  ($dnsRecords | Where-Object {$_.Type -eq "CNAME"} | measure).Count -ge 1
+    $currentHasA =  ($currentRecords | Where-Object {$_.Type -eq "A"} | measure).Count -ge 1
+    $currentHasCNAME =  ($currentRecords | Where-Object {$_.Type -eq "CNAME"} | measure).Count -ge 1
     if($currentHasCNAME -eq $true)
     {
         DeleteCName $dnsServer $domain $name
@@ -213,7 +213,7 @@ function DeleteARecord ([string]$dnsServer, [string]$domain, [string]$name)
 function CreateARecord ([string]$dnsServer, [string]$domain, [string]$name, [string]$ipAddress, [string]$ttl="3600")
 {
     write-host "Creating DNS A record for $name.$domain pointing at $ipAddress with TTL $ttl"
-    $result = dnscmd $dnsServer /recordAdd $domain $name A $ipAddress
+    $result = dnscmd $dnsServer /recordAdd $domain $name $ttl A $ipAddress
     $outcome = $false
     foreach ($item in $result)
     {
@@ -235,8 +235,8 @@ function UpdateARecord ([string]$dnsServer, [string]$domain, [string]$name, [str
 {
     $currentRecords = (GetDnsRecords $dnsServer $domain $name | Where-Object {$_.Record -eq $name.ToLower()})
     $currentTtl = ($currentRecords | Select-Object -ExpandProperty Ttl -First 1)
-    $currentHasA =  ($dnsRecords | Where-Object {$_.Type -eq "A"} | measure).Count -ge 1
-    $currentHasCNAME =  ($dnsRecords | Where-Object {$_.Type -eq "CNAME"} | measure).Count -ge 1
+    $currentHasA =  ($currentRecords | Where-Object {$_.Type -eq "A"} | measure).Count -ge 1
+    $currentHasCNAME =  ($currentRecords | Where-Object {$_.Type -eq "CNAME"} | measure).Count -ge 1
     if($currentHasCNAME -eq $true)
     {
         DeleteCName $dnsServer $domain $name


### PR DESCRIPTION
This change also has a more selective delete, as we can check the current type of the record.
We also ensure that we retain the TTL when we update records rather than reset to 3600