### PR TITLE
Hard fail on missing or broken XML

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -6,7 +6,7 @@ using System.Text.RegularExpressions;
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Release");
 
-var baseVersion = "1.7.4";
+var baseVersion = "1.7.5";
 var subVersion = "";
 var subVersionNumber = "";
 var isMasterOrDevelop = false;

--- a/src/Ensconce.Cake/EnsconceDeployDatabaseExtensions.cs
+++ b/src/Ensconce.Cake/EnsconceDeployDatabaseExtensions.cs
@@ -20,7 +20,7 @@ namespace Ensconce.Cake
         [CakeMethodAlias]
         public static void DeployDatabaseByConnectionString(this ICakeContext context, string connectionString, FilePath fixedStructureFile, DirectoryPath deployScriptDirectoryPath)
         {
-            var tagDictionary = fixedStructureFile == null ? TagDictionaryBuilder.Build(string.Empty) : TagDictionaryBuilder.Build(fixedStructureFile.FullPath);
+            var tagDictionary = fixedStructureFile == null ? TagDictionaryBuilder.BuildLazy(string.Empty) : TagDictionaryBuilder.BuildLazy(fixedStructureFile.FullPath);
             var connectionStringBuilder = new SqlConnectionStringBuilder(connectionString.RenderTemplate(tagDictionary));
             context.DeployDatabase(connectionStringBuilder, deployScriptDirectoryPath);
         }
@@ -34,7 +34,7 @@ namespace Ensconce.Cake
         [CakeMethodAlias]
         public static void DeployLocalDatabaseByName(this ICakeContext context, string databaseName, FilePath fixedStructureFile, DirectoryPath deployScriptDirectoryPath)
         {
-            var tagDictionary = fixedStructureFile == null ? TagDictionaryBuilder.Build(string.Empty) : TagDictionaryBuilder.Build(fixedStructureFile.FullPath);
+            var tagDictionary = fixedStructureFile == null ? TagDictionaryBuilder.BuildLazy(string.Empty) : TagDictionaryBuilder.BuildLazy(fixedStructureFile.FullPath);
             var connectionStringBuilder = Database.Database.GetLocalConnectionStringFromDatabaseName(databaseName.RenderTemplate(tagDictionary));
             context.DeployDatabase(connectionStringBuilder, deployScriptDirectoryPath);
         }

--- a/src/Ensconce.Cake/EnsconceDropDatabaseExtensions.cs
+++ b/src/Ensconce.Cake/EnsconceDropDatabaseExtensions.cs
@@ -27,7 +27,7 @@ namespace Ensconce.Cake
         [CakeMethodAlias]
         public static void DropDatabaseByConnectionString(this ICakeContext context, string connectionString, FilePath fixedStructureFile, DirectoryPath tempDirectoryPath)
         {
-            var tagDictionary = fixedStructureFile == null ? TagDictionaryBuilder.Build(string.Empty) : TagDictionaryBuilder.Build(fixedStructureFile.FullPath);
+            var tagDictionary = fixedStructureFile == null ? TagDictionaryBuilder.BuildLazy(string.Empty) : TagDictionaryBuilder.BuildLazy(fixedStructureFile.FullPath);
             var connectionStringBuilder = new SqlConnectionStringBuilder(connectionString.RenderTemplate(tagDictionary));
             context.DropDatabase(connectionStringBuilder, tempDirectoryPath);
         }
@@ -47,7 +47,7 @@ namespace Ensconce.Cake
         [CakeMethodAlias]
         public static void DropLocalDatabaseByName(this ICakeContext context, string databaseName, FilePath fixedStructureFile, DirectoryPath tempDirectoryPath)
         {
-            var tagDictionary = fixedStructureFile == null ? TagDictionaryBuilder.Build(string.Empty) : TagDictionaryBuilder.Build(fixedStructureFile.FullPath);
+            var tagDictionary = fixedStructureFile == null ? TagDictionaryBuilder.BuildLazy(string.Empty) : TagDictionaryBuilder.BuildLazy(fixedStructureFile.FullPath);
             var connectionStringBuilder = Database.Database.GetLocalConnectionStringFromDatabaseName(databaseName.RenderTemplate(tagDictionary));
             context.DropDatabase(connectionStringBuilder, tempDirectoryPath);
         }

--- a/src/Ensconce.Cake/EnsconceFileUpdateExtensions.cs
+++ b/src/Ensconce.Cake/EnsconceFileUpdateExtensions.cs
@@ -23,7 +23,7 @@ namespace Ensconce.Cake
 
         public static void TextSubstitute(this FilePath file, FilePath fixedStructureFile)
         {
-            var tagDictionary = fixedStructureFile == null ? TagDictionaryBuilder.Build(string.Empty) : TagDictionaryBuilder.Build(fixedStructureFile.FullPath);
+            var tagDictionary = fixedStructureFile == null ? TagDictionaryBuilder.BuildLazy(string.Empty) : TagDictionaryBuilder.BuildLazy(fixedStructureFile.FullPath);
             Update.ProcessFiles.UpdateFile(new FileInfo(file.FullPath), tagDictionary);
         }
 
@@ -34,7 +34,7 @@ namespace Ensconce.Cake
 
         public static void TextSubstitute(this DirectoryPath directory, string filter, FilePath fixedStructureFile)
         {
-            var tagDictionary = fixedStructureFile == null ? TagDictionaryBuilder.Build(string.Empty) : TagDictionaryBuilder.Build(fixedStructureFile.FullPath);
+            var tagDictionary = fixedStructureFile == null ? TagDictionaryBuilder.BuildLazy(string.Empty) : TagDictionaryBuilder.BuildLazy(fixedStructureFile.FullPath);
             Update.ProcessFiles.UpdateFiles(directory.FullPath, filter, tagDictionary);
         }
     }

--- a/src/Ensconce.Cli/DictionaryExport.cs
+++ b/src/Ensconce.Cli/DictionaryExport.cs
@@ -9,7 +9,7 @@ namespace Ensconce.Cli
     {
         internal static void ExportTagDictionary()
         {
-            var tagDictionary = TagDictionaryBuilder.Build(Arguments.FixedPath);
+            var tagDictionary = TagDictionaryBuilder.BuildLazy(Arguments.FixedPath);
             var tagDictionaryJson = JsonConvert.SerializeObject(tagDictionary, Formatting.Indented);
 
             if (!string.IsNullOrWhiteSpace(Arguments.DictionarySavePath))

--- a/src/Ensconce.Cli/TagSubstitution.cs
+++ b/src/Ensconce.Cli/TagSubstitution.cs
@@ -7,13 +7,13 @@ namespace Ensconce.Cli
     {
         internal static void DefaultUpdate()
         {
-            var tagDictionary = TagDictionaryBuilder.Build(Arguments.FixedPath);
+            var tagDictionary = TagDictionaryBuilder.BuildLazy(Arguments.FixedPath);
             ProcessSubstitution.Update(Arguments.SubstitutionPath, tagDictionary, Arguments.OutputFailureContext);
         }
 
         internal static void UpdateFiles()
         {
-            var tagDictionary = TagDictionaryBuilder.Build(Arguments.FixedPath);
+            var tagDictionary = TagDictionaryBuilder.BuildLazy(Arguments.FixedPath);
             ProcessFiles.UpdateFiles(Arguments.DeployFrom, Arguments.TemplateFilters, tagDictionary);
         }
     }

--- a/src/Ensconce.Cli/TextRendering.cs
+++ b/src/Ensconce.Cli/TextRendering.cs
@@ -6,7 +6,7 @@ namespace Ensconce.Cli
     {
         internal static string Render(this string s)
         {
-            var tagDictionary = TagDictionaryBuilder.Build(Arguments.FixedPath);
+            var tagDictionary = TagDictionaryBuilder.BuildLazy(Arguments.FixedPath);
             return s.RenderTemplate(tagDictionary);
         }
     }

--- a/src/Ensconce.Update.Tests/TagDictionaryTestFiles/invalidStructure.xml
+++ b/src/Ensconce.Update.Tests/TagDictionaryTestFiles/invalidStructure.xml
@@ -1,2 +1,3 @@
 ﻿<Structure xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  No&AllowedInXML
 </Structure>

--- a/src/Ensconce.Update/TagDictionary.cs
+++ b/src/Ensconce.Update/TagDictionary.cs
@@ -126,14 +126,19 @@ namespace Ensconce.Update
 
         private void PropertiesFromXml(string identifier, string xmlData)
         {
+            if (string.IsNullOrWhiteSpace(xmlData))
+            {
+                return;
+            }
+
             XDocument doc;
             try
             {
                 doc = XDocument.Parse(xmlData);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                return;
+                throw new XmlException("Unable to parse XML data", ex);
             }
 
             ValidateStructureFile(doc);
@@ -151,7 +156,7 @@ namespace Ensconce.Update
 
             schemas.Add(null, XmlReader.Create(assembly.GetManifestResourceStream("Ensconce.Update.FixedStructure.xsd")));
 
-            doc.Validate(schemas, (sender, args) => { throw args.Exception; });
+            doc.Validate(schemas, (sender, args) => throw args.Exception);
         }
 
         private void BasePropertiesFromXml(XDocument doc)


### PR DESCRIPTION
If fixed structure file doesn't exist or the xml is invalid hard fail
This prevents invalid or missing files from causing strange hidden effects like a tag not existing.