### PR TITLE
Create polyfill for powershell 4

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -6,7 +6,7 @@ using System.Text.RegularExpressions;
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Release");
 
-var baseVersion = "1.7.5";
+var baseVersion = "1.7.6";
 var subVersion = "";
 var subVersionNumber = "";
 var isMasterOrDevelop = false;

--- a/src/Ensconce.sln
+++ b/src/Ensconce.sln
@@ -30,6 +30,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Scripts", "Scripts", "{C23A
 		Scripts\deployHelp.ps1 = Scripts\deployHelp.ps1
 		Scripts\dnsHelper.ps1 = Scripts\dnsHelper.ps1
 		Scripts\kubernetesHelper.ps1 = Scripts\kubernetesHelper.ps1
+		Scripts\powershell4Polyfill.ps1 = Scripts\powershell4Polyfill.ps1
 		Scripts\rabbitHelper.ps1 = Scripts\rabbitHelper.ps1
 		Scripts\scheduledTaskHelper.ps1 = Scripts\scheduledTaskHelper.ps1
 		Scripts\serviceManagement.ps1 = Scripts\serviceManagement.ps1
@@ -55,7 +56,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ensconce.Cake", "Ensconce.C
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ensconce.Helpers", "Ensconce.Helpers\Ensconce.Helpers.csproj", "{4E35B578-FFB8-4A9F-8E1D-DCCAEA15213F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ensconce.NDjango.Custom", "Ensconce.NDjango.Custom\Ensconce.NDjango.Custom.csproj", "{07E449DA-15D3-494F-A6CF-26C56B5620D3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ensconce.NDjango.Custom", "Ensconce.NDjango.Custom\Ensconce.NDjango.Custom.csproj", "{07E449DA-15D3-494F-A6CF-26C56B5620D3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Scripts/deployHelp.ps1
+++ b/src/Scripts/deployHelp.ps1
@@ -11,6 +11,11 @@ Write-Host "Ensconce - Ensconce Version: $ensconceVersion"
 $psVersion = (Get-Host).Version
 Write-Host "Ensconce - Powershell Version: $psVersion"
 
+if ($psVersion.Version.Major -le 4)
+{
+    . $currentDirectory\powershell4Polyfill.ps1
+}
+
 Write-Host "Ensconce - Setting SecurityProtocol to TLS 1.1 or TLS 1.2"
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls11 -bor [System.Net.SecurityProtocolType]::Tls12;
 

--- a/src/Scripts/powershell4Polyfill.ps1
+++ b/src/Scripts/powershell4Polyfill.ps1
@@ -2,6 +2,8 @@ Write-Host "Ensconce - Powershell4Polyfill Loading"
 
 function Clear-DnsClientCache()
 {
+	Write-Host "Calling IPConfig /flushdns to simulate Powershell 5 function"
+
 	$ProcessInfo = New-Object System.Diagnostics.ProcessStartInfo
 	$ProcessInfo.FileName = "ipconfig.exe"
 	$ProcessInfo.RedirectStandardError = $true

--- a/src/Scripts/powershell4Polyfill.ps1
+++ b/src/Scripts/powershell4Polyfill.ps1
@@ -1,0 +1,21 @@
+Write-Host "Ensconce - Powershell4Polyfill Loading"
+
+function Clear-DnsClientCache()
+{
+	$ProcessInfo = New-Object System.Diagnostics.ProcessStartInfo
+	$ProcessInfo.FileName = "ipconfig.exe"
+	$ProcessInfo.RedirectStandardError = $true
+	$ProcessInfo.RedirectStandardOutput = $true
+	$ProcessInfo.UseShellExecute = $false
+	$ProcessInfo.Arguments = "/flushdns"
+
+	$Process = New-Object System.Diagnostics.Process
+	$Process.StartInfo = $ProcessInfo
+	$Process.Start() | Out-Null
+	$Process.WaitForExit()
+
+	$output = $Process.StandardOutput.ReadToEnd()
+	write-host $output
+}
+
+Write-Host "Ensconce - Powershell4Polyfill Loaded"


### PR DESCRIPTION
Automatically load powershell 4 polyfill when when powershell major version is 4 or less

The powershell function `Clear-DnsClientCache` is added in powershell 5.
So this means that powershell 4 will be able to "support" it