### PR TITLE
Fix handingling Of Flat Groups

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,4 +1,4 @@
-#module nuget:?package=Cake.BuildSystems.Module&version=3.0.1
+﻿#module nuget:?package=Cake.BuildSystems.Module&version=3.0.1
 #tool "nuget:?package=OctopusTools&version=7.4.3127"
 
 using System.Text.RegularExpressions;
@@ -6,7 +6,7 @@ using System.Text.RegularExpressions;
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Release");
 
-var baseVersion = "1.7.6";
+var baseVersion = "1.7.7";
 var subVersion = "";
 var subVersionNumber = "";
 var isMasterOrDevelop = false;

--- a/src/Ensconce.Update.Tests/TagDictionaryTestFiles/webservice-structure.xml
+++ b/src/Ensconce.Update.Tests/TagDictionaryTestFiles/webservice-structure.xml
@@ -60,10 +60,10 @@
         <Property name="Value">888</Property>
       </Properties>
     </PropertyGroup>
-    <PropertyGroup label="FlatGroup" identity="0">
+    <PropertyGroup label="FlatGroup" identity="FG0">
       <Property name="Value">FlatGroup-0</Property>
     </PropertyGroup>
-    <PropertyGroup label="FlatGroup" identity="1">
+    <PropertyGroup label="FlatGroup" identity="FG1">
       <Property name="Value">FlatGroup-1</Property>
     </PropertyGroup>
   </PropertyGroups>

--- a/src/Ensconce.Update.Tests/TagDictionaryTests.cs
+++ b/src/Ensconce.Update.Tests/TagDictionaryTests.cs
@@ -68,6 +68,20 @@ namespace Ensconce.Update.Tests
         }
 
         [Test]
+        public void IdentifiedPropertiesTakePrecedence_ForFlatGroups()
+        {
+            var loader = TagDictionary.FromSources("FG1", new Dictionary<TagSource, string> { { TagSource.XmlData, XmlData } });
+            Assert.AreEqual("FlatGroup-1", loader["Value"]);
+        }
+
+        [Test]
+        public void IdentifiedPropertiesTakePrecedence_WhenLabelIncluded()
+        {
+            var loader = TagDictionary.FromSources("Label1.1", new Dictionary<TagSource, string> { { TagSource.XmlData, XmlData } });
+            Assert.AreEqual("321CBA", loader["Value"]);
+        }
+
+        [Test]
         public void LoadFromEnvironment()
         {
             var loader = TagDictionary.FromSources("ident", new Dictionary<TagSource, string> { { TagSource.Environment, "" } });
@@ -710,8 +724,8 @@ namespace Ensconce.Update.Tests
         public void FlatLabelGroupsHaveValues()
         {
             var sut = TagDictionary.FromSources("ident", new Dictionary<TagSource, string> { { TagSource.XmlData, XmlData } });
-            Assert.AreEqual("FlatGroup-0", "{{ FlatGroup.0.Value }}".RenderTemplate(sut.ToLazyTagDictionary()));
-            Assert.AreEqual("FlatGroup-1", "{{ FlatGroup.1.Value }}".RenderTemplate(sut.ToLazyTagDictionary()));
+            Assert.AreEqual("FlatGroup-0", "{{ FlatGroup.FG0.Value }}".RenderTemplate(sut.ToLazyTagDictionary()));
+            Assert.AreEqual("FlatGroup-1", "{{ FlatGroup.FG1.Value }}".RenderTemplate(sut.ToLazyTagDictionary()));
         }
 
         [Test]


### PR DESCRIPTION
Flat groups do not have a nested "Properties" node so the logic was not picking up the "Property" nodes.

Also, found (when writing a test) that if you have 2 sets groups with the same idententity (e.g. numbers) it's impossible to do a identity filtered model for those.  So support the identifier parameter also having a "." (which cannot be in property names etc) so say you want label.identity.