### PR TITLE
Fix usage of namespace in `ifNotExists`

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -6,7 +6,7 @@ using System.Text.RegularExpressions;
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Release");
 
-var baseVersion = "1.10.1";
+var baseVersion = "1.10.2";
 var subVersion = "";
 var subVersionNumber = "";
 var isMasterOrDevelop = false;

--- a/src/Ensconce.Update.Tests/TestUpdateFiles/TestSubstitution38.xml
+++ b/src/Ensconce.Update.Tests/TestUpdateFiles/TestSubstitution38.xml
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Root xmlns="http://15below.com/Substitutions.xsd">
+  <Namespaces>
+    <Namespace Prefix="madeup">http://madeup.com</Namespace>
+  </Namespaces>
+  <Files>
+    <File Filename="TestUpdateFiles\TestConfig2.xml">
+      <Changes>
+        <Change>
+          <XPath>/madeup:root/madeup:value</XPath>
+          <ReplacementContent></ReplacementContent>
+        </Change>
+        <Change type="AddChildContent" xPath="/madeup:root/madeup:value" ifNotExists="/madeup:root/madeup:value/madeup:child1">
+          <Content>
+            <![CDATA[<child1 />]]>
+          </Content>
+        </Change>
+        <Change type="AddChildContent" xPath="/madeup:root/madeup:value" ifNotExists="/madeup:root/madeup:value/madeup:child2">
+          <Content>
+            <![CDATA[<child2 />]]>
+          </Content>
+        </Change>
+      </Changes>
+    </File>
+  </Files>
+</Root>

--- a/src/Ensconce.Update.Tests/UpdateFileTests.cs
+++ b/src/Ensconce.Update.Tests/UpdateFileTests.cs
@@ -504,6 +504,19 @@ namespace Ensconce.Update.Tests
         }
 
         [Test]
+        public void XmlIfNotExists_WithNamespace()
+        {
+            var newConfig = XDocument.Parse(ProcessSubstitution.Update(
+                @"TestUpdateFiles\TestSubstitution38.xml", @"TestUpdateFiles\TestConfig2.xml"
+            ));
+
+            var nsm = new XmlNamespaceManager(new NameTable());
+            nsm.AddNamespace("x", "http://madeup.com");
+
+            Assert.AreEqual(2, newConfig.XPathSelectElement("/x:root/x:value", nsm)?.Nodes().Count());
+        }
+
+        [Test]
         public void SubstituteIf_True()
         {
             var newConfig = XDocument.Parse(ProcessSubstitution.Update(

--- a/src/Ensconce.Update/ProcessSubsitution.cs
+++ b/src/Ensconce.Update/ProcessSubsitution.cs
@@ -250,7 +250,7 @@ namespace Ensconce.Update
                 {
                     if (sub.HasAddChildContent)
                     {
-                        AddChildContentToActive(tagValues, activeNode, sub);
+                        AddChildContentToActive(tagValues, activeNode, sub, baseNsm);
                     }
 
                     if (sub.HasReplacementContent)
@@ -308,9 +308,9 @@ namespace Ensconce.Update
             activeNode.AddAfterSelf(fakeRoot.Elements());
         }
 
-        private static void AddChildContentToActive(Lazy<TagDictionary> tagValues, XContainer activeNode, Substitution sub)
+        private static void AddChildContentToActive(Lazy<TagDictionary> tagValues, XContainer activeNode, Substitution sub, XmlNamespaceManager nsm)
         {
-            if (sub.AddChildContentIfNotExists == null || activeNode.Document?.XPathSelectElement(sub.AddChildContentIfNotExists.RenderTemplate(tagValues)) == null)
+            if (sub.AddChildContentIfNotExists == null || activeNode.Document?.XPathSelectElement(sub.AddChildContentIfNotExists.RenderTemplate(tagValues), nsm) == null)
             {
                 var fakeRoot = XElement.Parse("<fakeRoot>" + sub.AddChildContent.RenderXmlTemplate(tagValues) + "</fakeRoot>");
                 activeNode.Add(fakeRoot.Elements());


### PR DESCRIPTION
If the xml file being updated has namespaces then the `ifNotExists` with a namespace doesn't work.

This fix means that the namespaces can also be used in the xPath for the `ifNotExists`