### PR TITLE
Remove kubectl from being part of Ensconce

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -6,7 +6,7 @@ using System.Text.RegularExpressions;
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Release");
 
-var baseVersion = "1.10.2";
+var baseVersion = "1.11.0";
 var subVersion = "";
 var subVersionNumber = "";
 var isMasterOrDevelop = false;
@@ -168,11 +168,9 @@ Task("Publish")
     CreateDirectory("./output/publish/Content");
     CreateDirectory("./output/publish/Content/Tools");
     CreateDirectory("./output/publish/Content/Tools/Grant");
-    CreateDirectory("./output/publish/Content/Tools/KubeCtl");
     CreateDirectory("./output/publish/Content/Tools/Ensconce");
 
     CopyFiles("./src/ExternalDeployTools/Grant/*", "./output/publish/Content/Tools/Grant");
-    CopyFiles("./src/ExternalDeployTools/KubeCtl/*", "./output/publish/Content/Tools/KubeCtl");
     CopyFiles("./src/Scripts/*.ps1", "./output/publish/Content");
     CopyFiles("./src/Deploy/*.ps1", "./output/publish");
     CopyFiles("./src/Deploy/*.xml", "./output/publish");

--- a/docs/powershell/kubernetes-helper/index.md
+++ b/docs/powershell/kubernetes-helper/index.md
@@ -10,7 +10,7 @@ linkText: kubernetesHelper.ps1
 
 The `kubernetesHelper.ps1` script has functionality to interact with a Kubernetes environment
 
-*NOTE: This will only be available if `includeK8s` variable is set to `True` on deploy*
+*NOTE: The path to kubectl should be `C:\KubeCtl\kubectl.exe` but can be changed with an Octopus variable `KubeCtlExe`*
 
 ## Functions
 

--- a/src/Deploy/deploy.ps1
+++ b/src/Deploy/deploy.ps1
@@ -10,21 +10,6 @@ if(Test-Path $DeployPath)
 Write-Host "Creating Deploy Tools Directory at $DeployPath"
 New-Item -Path $DeployPath -Type container -Force | Out-Null
 
-if($IncludeK8s -eq "True")
-{
-	Write-Host "Ensconce deployed in Kubernetes mode as 'IncludeK8s' set to 'True'"
-	Remove-Item "$scriptDir\Content\backupHelper.ps1" -Force
-	Remove-Item "$scriptDir\Content\createWebSite.ps1" -Force
-	Remove-Item "$scriptDir\Content\dnsHelper.ps1" -Force
-	Remove-Item "$scriptDir\Content\serviceManagement.ps1" -Force
-}
-else
-{
-	Write-Host "Ensconce deployed in application deployment mode as 'IncludeK8s' NOT set to 'True'"
-	Remove-Item "$scriptDir\Content\Tools\KubeCtl" -Force -Recurse
-	Remove-Item "$scriptDir\Content\kubernetesHelper.ps1" -Force
-}
-
 Get-ChildItem -Path $scriptDir\Content\*.ps1 | ForEach-Object {
 	$scriptName = $_.Name
 	$scriptFullName = $_.FullName

--- a/src/Scripts/kubernetesHelper.ps1
+++ b/src/Scripts/kubernetesHelper.ps1
@@ -6,8 +6,27 @@ if($deployHelpLoaded -eq $null)
 }
 
 Write-Host "Ensconce - KubernetesHelper Loading"
-$KubeCtlExe = "$currentDirectory\Tools\KubeCtl\kubectl.exe"
+if([string]::IsNullOrWhiteSpace($KubeCtlExe))
+{
+	$KubeCtlExe = "C:\KubeCtl\kubectl.exe"
+}
 $rootConfigPath = "$Home\.kube"
+
+if (Test-Path $KubeCtlExe)
+{
+    (& $KubeCtlExe version --client 2>&1) | ForEach-Object {
+        if($_ -match "^Client Version.*")
+        {
+            $data = ConvertFrom-Json ($_ -replace "Client Version: version.Info", "")
+            $clientVersion = $data.GitVersion
+            Write-Host "KubeCtl Version: $clientVersion"
+        }
+    }
+}
+else
+{
+    throw "'$KubeCtlExe' doesn't exist"
+}
 
 function PreProcessYaml([string]$yamlDirectory)
 {


### PR DESCRIPTION
Change assumes kubectl exists at `C:\KubeCtl\kubectl.exe` but can also already be provided in a variable `$KubeCtlExe` (or as an octopus variable)