### PR TITLE
Introduce support for Handle.exe to remove handles in a directory after stopping services and processes

### DIFF
--- a/src/Ensconce.Cli/ApplicationInteraction.cs
+++ b/src/Ensconce.Cli/ApplicationInteraction.cs
@@ -179,6 +179,7 @@ namespace Ensconce.Cli
             p.StartInfo.CreateNoWindow = true;
             p.StartInfo.FileName = handleExe;
             p.StartInfo.Arguments = $"{searchFolder} /nobanner";
+            p.StartInfo.Verb = "runas";
             p.Start();
             var output = p.StandardOutput.ReadToEnd();
             p.WaitForExit();
@@ -194,6 +195,7 @@ namespace Ensconce.Cli
             p.StartInfo.CreateNoWindow = true;
             p.StartInfo.FileName = handleExe;
             p.StartInfo.Arguments = $"-c {handleHash} -y -p {pid} /nobanner";
+            p.StartInfo.Verb = "runas";
             p.Start();
             p.WaitForExit();
             if (p.ExitCode != 0)

--- a/src/Ensconce.Cli/ApplicationInteraction.cs
+++ b/src/Ensconce.Cli/ApplicationInteraction.cs
@@ -74,7 +74,7 @@ namespace Ensconce.Cli
                         // Process has already terminated.
                     }
 
-                    process.Process.WaitForExit();
+                    process.Process.WaitForExit((int)TimeSpan.FromSeconds(30).TotalMilliseconds);
                 }
             }
             else

--- a/src/Ensconce.Cli/Arguments.cs
+++ b/src/Ensconce.Cli/Arguments.cs
@@ -34,6 +34,8 @@ namespace Ensconce.Cli
         internal static string DictionaryPostUrl { get; private set; }
         internal static string DictionarySavePath { get; private set; }
 
+        internal static string DeployToolsDir { get; private set; }
+
         internal static List<string> BackupSources { get; private set; } = new List<string>();
         internal static string BackupDestination { get; private set; }
         internal static bool BackupOverwrite { get; private set; }
@@ -75,6 +77,9 @@ namespace Ensconce.Cli
 
             var envRoundhouseOutputPath = Environment.GetEnvironmentVariable("RoundhouseOutputPath");
             RoundhouseOutputPath = !string.IsNullOrEmpty(envRoundhouseOutputPath) ? envRoundhouseOutputPath : @"E:\RH\";
+
+            var envDeployToolsDir = Environment.GetEnvironmentVariable("DeployToolsDir");
+            DeployToolsDir = !string.IsNullOrEmpty(envDeployToolsDir) ? envDeployToolsDir : string.Empty;
         }
 
         private static OptionSet GetOptionSet()

--- a/src/Ensconce.Cli/FileInteraction.cs
+++ b/src/Ensconce.Cli/FileInteraction.cs
@@ -21,7 +21,7 @@ namespace Ensconce.Cli
             ApplicationInteraction.StopProcessesInDirectory(directory);
 
             // Try and kill handles in the dir
-            ApplicationInteraction.KillHandlesInDirectory(directory);
+            ApplicationInteraction.ReleaseHandlesInDirectory(directory);
 
             Logging.Log("Deleting from {0}", directory);
             PerformDelete(new DirectoryInfo(directory));

--- a/src/Ensconce.Cli/FileInteraction.cs
+++ b/src/Ensconce.Cli/FileInteraction.cs
@@ -20,39 +20,42 @@ namespace Ensconce.Cli
             // Try and kill processes we know about in the dir
             ApplicationInteraction.StopProcessesInDirectory(directory);
 
-            // Try and kill handles in the dir
-            ApplicationInteraction.ReleaseHandlesInDirectory(directory);
-
             Logging.Log("Deleting from {0}", directory);
-            PerformDelete(new DirectoryInfo(directory));
+            var directoryInfo = new DirectoryInfo(directory);
 
-            Logging.Log("Ensure Directory {0} has been deleted", directory);
-            Retry.Do(() =>
-            {
-                if (Directory.Exists(directory))
-                {
-                    throw new Exception("Directory still exists");
-                }
-            }, TimeSpan.FromMilliseconds(1000));
-        }
-
-        private static void PerformDelete(DirectoryInfo directory)
-        {
             // Disable any read-only flags
-            directory.Attributes = FileAttributes.Normal;
+            directoryInfo.Attributes = FileAttributes.Normal;
 
-            foreach (var dir in directory.EnumerateDirectories("*", SearchOption.AllDirectories))
+            foreach (var dir in directoryInfo.EnumerateDirectories("*", SearchOption.AllDirectories))
             {
                 dir.Attributes = FileAttributes.Normal;
             }
 
-            foreach (var file in directory.EnumerateFiles("*", SearchOption.AllDirectories))
+            foreach (var file in directoryInfo.EnumerateFiles("*", SearchOption.AllDirectories))
             {
                 file.Attributes = FileAttributes.Normal;
             }
 
             // Delete directory tree
-            Retry.Do(() => directory.Delete(true), TimeSpan.FromMilliseconds(1000));
+            Retry.Do(retry =>
+            {
+                if (retry > 0)
+                {
+                    // Try and kill handles in the dir
+                    ApplicationInteraction.ReleaseHandlesInDirectory(directory);
+                }
+
+                directoryInfo.Delete(true);
+            }, TimeSpan.FromMilliseconds(1000));
+
+            Logging.Log("Ensure Directory {0} has been deleted", directory);
+            Retry.Do(() =>
+            {
+                if (directoryInfo.Exists)
+                {
+                    throw new Exception("Directory still exists");
+                }
+            }, TimeSpan.FromMilliseconds(1000));
         }
 
         internal static void CopyDirectory(string from, string to)

--- a/src/Ensconce.Cli/FileInteraction.cs
+++ b/src/Ensconce.Cli/FileInteraction.cs
@@ -14,11 +14,14 @@ namespace Ensconce.Cli
                 return;
             }
 
-            // Check for and uninstall services installed in directory
-            ApplicationInteraction.StopAndDeleteServicesInDirectory(directory);
+            Retry.Do(() =>
+            {
+                // Check for and uninstall services installed in directory
+                ApplicationInteraction.StopAndDeleteServicesInDirectory(directory);
 
-            // Try and kill processes we know about in the dir
-            ApplicationInteraction.StopProcessesInDirectory(directory);
+                // Try and kill processes we know about in the dir
+                ApplicationInteraction.StopProcessesInDirectory(directory);
+            }, TimeSpan.FromMilliseconds(1000));
 
             Logging.Log("Deleting from {0}", directory);
             var directoryInfo = new DirectoryInfo(directory);

--- a/src/Ensconce.Cli/FileInteraction.cs
+++ b/src/Ensconce.Cli/FileInteraction.cs
@@ -20,6 +20,9 @@ namespace Ensconce.Cli
             // Try and kill processes we know about in the dir
             ApplicationInteraction.StopProcessesInDirectory(directory);
 
+            // Try and kill handles in the dir
+            ApplicationInteraction.KillHandlesInDirectory(directory);
+
             Logging.Log("Deleting from {0}", directory);
             PerformDelete(new DirectoryInfo(directory));
 

--- a/src/Ensconce.Helpers/Retry.cs
+++ b/src/Ensconce.Helpers/Retry.cs
@@ -15,9 +15,14 @@ namespace Ensconce.Helpers
 
         public static void Do(Action action, TimeSpan retryInterval, Type[] doNotRetryTheseExceptions = null)
         {
-            Do<object>(() =>
+            Do(_ => action(), retryInterval, doNotRetryTheseExceptions);
+        }
+
+        public static void Do(Action<int> action, TimeSpan retryInterval, Type[] doNotRetryTheseExceptions = null)
+        {
+            Do<object>(retry =>
                 {
-                    action();
+                    action(retry);
                     return null;
                 },
                 retryInterval,
@@ -26,13 +31,18 @@ namespace Ensconce.Helpers
 
         public static T Do<T>(Func<T> action, TimeSpan retryInterval, Type[] doNotRetryTheseExceptions = null)
         {
+            return Do(_ => action(), retryInterval, doNotRetryTheseExceptions);
+        }
+
+        public static T Do<T>(Func<int, T> action, TimeSpan retryInterval, Type[] doNotRetryTheseExceptions = null)
+        {
             var exceptions = new List<Exception>();
 
             for (var retry = 0; retry < retryCount; retry++)
             {
                 try
                 {
-                    return action();
+                    return action(retry);
                 }
                 catch (Exception ex) when (doNotRetryTheseExceptions?.Any(t => ex.GetType() == t) == true)
                 {

--- a/src/Scripts/deployHelp.ps1
+++ b/src/Scripts/deployHelp.ps1
@@ -7,6 +7,7 @@ if ((Test-Path $DeployToolsDir\releaseVersion.txt) -eq $true)
     $ensconceVersion = Get-Content -Path $DeployToolsDir\releaseVersion.txt -TotalCount 1
 }
 Write-Host "Ensconce - Ensconce Version: $ensconceVersion"
+Set-Content "env:\DeployToolsPath" "$DeployToolsDir\Tools"
 
 $psVersion = (Get-Host).Version
 Write-Host "Ensconce - Powershell Version: $psVersion"


### PR DESCRIPTION
Situations where unknown processes (like an antivirus) has a handle locked on the file.