### PR TITLE
Update regroup to handle if the input items being grouped on are not in order

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -6,7 +6,7 @@ using System.Text.RegularExpressions;
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Release");
 
-var baseVersion = "1.24.7";
+var baseVersion = "1.24.8";
 var subVersion = "";
 var subVersionNumber = "";
 var isMasterOrDevelop = false;

--- a/build.cake
+++ b/build.cake
@@ -6,7 +6,7 @@ using System.Text.RegularExpressions;
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Release");
 
-var baseVersion = "1.24.8";
+var baseVersion = "1.24.9";
 var subVersion = "";
 var subVersionNumber = "";
 var isMasterOrDevelop = false;

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -226,7 +226,7 @@ GEM
       jekyll-seo-tag (~> 2.1)
     minitest (5.22.3)
     multipart-post (2.1.1)
-    nokogiri (1.16.4)
+    nokogiri (1.16.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octokit (4.21.0)

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -239,7 +239,8 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.2.5)
+    rexml (3.2.8)
+      strscan (>= 3.0.9)
     rouge (3.26.0)
     ruby-enum (0.9.0)
       i18n
@@ -256,6 +257,7 @@ GEM
       faraday (> 0.8, < 2.0)
     simpleidn (0.2.1)
       unf (~> 0.1.4)
+    strscan (3.1.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thread_safe (0.3.6)

--- a/src/Ensconce.NDjango.Tests/MiscellaneousTags.cs
+++ b/src/Ensconce.NDjango.Tests/MiscellaneousTags.cs
@@ -100,6 +100,14 @@ new inner2
                 new ContextObjects.Person("Pat","Smith","Unknown")
             };
 
+            ContextObjects.Person[] peopleUnordered = new ContextObjects.Person[] {
+                new ContextObjects.Person("George", "Bush","Male"),
+                new ContextObjects.Person("Margaret","Thatcher","Female"),
+                new ContextObjects.Person("Bill","Clinton","Male"),
+                new ContextObjects.Person("Pat","Smith","Unknown"),
+                new ContextObjects.Person("Condoleezza","Rice","Female")
+            };
+
             // regroup tag
             lst.Add(new TestDescriptor("regroup-01",
 @"{% regroup people by gender as gender_list %}<ul>{% for gender in gender_list %}
@@ -112,6 +120,36 @@ new inner2
                 ContextObjects.p("people", people),
                 ContextObjects.p(
 @"<ul>
+    <li>Male
+    <ul>
+        <li>George Bush</li>
+        <li>Bill Clinton</li>
+    </ul>
+    </li>
+    <li>Female
+    <ul>
+        <li>Margaret Thatcher</li>
+        <li>Condoleezza Rice</li>
+    </ul>
+    </li>
+    <li>Unknown
+    <ul>
+        <li>Pat Smith</li>
+    </ul>
+    </li>
+</ul>")));
+
+            lst.Add(new TestDescriptor("regroup-02",
+                @"{% regroup people by gender as gender_list %}<ul>{% for gender in gender_list %}
+    <li>{{ gender.grouper }}
+    <ul>{% for item in gender.list %}
+        <li>{{ item.first_name }} {{ item.last_name }}</li>{% endfor %}
+    </ul>
+    </li>{% endfor %}
+</ul>",
+                ContextObjects.p("people", peopleUnordered),
+                ContextObjects.p(
+                    @"<ul>
     <li>Male
     <ul>
         <li>George Bush</li>

--- a/src/Scripts/kubernetesHelper.ps1
+++ b/src/Scripts/kubernetesHelper.ps1
@@ -259,7 +259,12 @@ function GetResourceVersionsUsed([string]$kubernetesConfigFile, [string]$selecto
     Write-Host "Get Accessible Resources"
     $resourceVersions = @()
     $resources = @()
-    $knownResourcesArray = $knownResources.Split(",",[System.StringSplitOptions]::RemoveEmptyEntries)
+    $knownResourcesArray = @()
+
+    if($knownResources -ne $null)
+    {
+        $knownResourcesArray = $knownResources.Split(",",[System.StringSplitOptions]::RemoveEmptyEntries)
+    }
 
     $rawResources = & $KubeCtlExe api-resources --verbs=list --namespaced -o name --kubeconfig=$kubernetesConfigFilePath
 


### PR DESCRIPTION
This splits list of groups on the index with the right value.
Then joins before the item, the items updated with new element in list, after the item.