### PR TITLE
BDB-1259: Default filter allows for whitespace before the filter argument

### DIFF
--- a/src/Ensconce.Database.Tests/Ensconce.Database.Tests.csproj
+++ b/src/Ensconce.Database.Tests/Ensconce.Database.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Description>Tests For Ensconce.Database</Description>
     <Company>15below</Company>
     <Product>Ensconce</Product>

--- a/src/Ensconce.NDjango.Core/Constants.fs
+++ b/src/Ensconce.NDjango.Core/Constants.fs
@@ -83,7 +83,7 @@ module Constants =
                 Replace("%(strs)s", "[^'\\\\]*(?:\\\\.[^'\\\\]*)*").
                 Replace("%(var_chars)s", @"\w\.-"). // apparently the python \w also captures the (-) sign, whereas the .net doesn't. including this here means we also need to check for it in Variable as an illegal first character
                 Replace("%(filter_sep)s", "(\s*)" + !!FILTER_SEPARATOR + "(\s*)").
-                Replace("%(arg_sep)s", !!FILTER_ARGUMENT_SEPARATOR).
+                Replace("%(arg_sep)s", !!FILTER_ARGUMENT_SEPARATOR + "(?:\s*)").
                 Replace("%(i18n_open)s", !!I18N_OPEN).
                 Replace("%(i18n_close)s", !!I18N_CLOSE), RegexOptions.Compiled)
 

--- a/src/Ensconce.NDjango.Tests/BasicSyntax.cs
+++ b/src/Ensconce.NDjango.Tests/BasicSyntax.cs
@@ -8,13 +8,13 @@ namespace Ensconce.NDjango.Tests
 {
     public partial class TestsRunner
     {
-        [Test, TestCaseSource("GetBasicTests")]
+        [Test, TestCaseSource(nameof(GetBasicTests))]
         public void BasicSyntax(TestDescriptor test)
         {
             test.Run(manager);
         }
 
-        public static IList<TestDescriptor> GetBasicTests()
+        private static IList<TestDescriptor> GetBasicTests()
         {
             IList<TestDescriptor> lst = new List<TestDescriptor>();
             //*

--- a/src/Ensconce.NDjango.Tests/Designer.cs
+++ b/src/Ensconce.NDjango.Tests/Designer.cs
@@ -24,7 +24,7 @@ namespace Ensconce.NDjango.Tests
         }
 
         //        [Test, TestCaseSource("GetDesignerTests")]
-        public void DesignerTests(TestDescriptor test)
+        private void DesignerTests(TestDescriptor test)
         {
             DesignerTest(test);
         }
@@ -82,7 +82,7 @@ namespace Ensconce.NDjango.Tests
                 ).Run(managerForDesigner);
         }
 
-        public IEnumerable<TestDescriptor> GetDesignerTests()
+        private IEnumerable<TestDescriptor> GetDesignerTests()
         {
             //SetupStandartdValues();
             throw new Exception();

--- a/src/Ensconce.NDjango.Tests/Ensconce.NDjango.Tests.csproj
+++ b/src/Ensconce.NDjango.Tests/Ensconce.NDjango.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Description>Tests For Ensconce.NDjango</Description>
     <Company>15below</Company>
     <Product>Ensconce</Product>
@@ -21,6 +21,10 @@
 
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
   </ItemGroup>

--- a/src/Ensconce.NDjango.Tests/IfTags.cs
+++ b/src/Ensconce.NDjango.Tests/IfTags.cs
@@ -7,13 +7,13 @@ namespace Ensconce.NDjango.Tests
 {
     public partial class TestsRunner
     {
-        [Test, TestCaseSource("GetIfTagTests")]
+        [Test, TestCaseSource(nameof(GetIfTagTests))]
         public void IfTag(TestDescriptor test)
         {
             test.Run(manager);
         }
 
-        public static IList<TestDescriptor> GetIfTagTests()
+        private static IList<TestDescriptor> GetIfTagTests()
         {
             IList<TestDescriptor> lst = new List<TestDescriptor>();
 

--- a/src/Ensconce.NDjango.Tests/LoopTags.cs
+++ b/src/Ensconce.NDjango.Tests/LoopTags.cs
@@ -7,13 +7,13 @@ namespace Ensconce.NDjango.Tests
 {
     public partial class TestsRunner
     {
-        [Test, TestCaseSource("GetLoopTagsTests")]
+        [Test, TestCaseSource(nameof(GetLoopTagsTests))]
         public void LoopTags(TestDescriptor test)
         {
             test.Run(manager);
         }
 
-        public static IList<TestDescriptor> GetLoopTagsTests()
+        private static IList<TestDescriptor> GetLoopTagsTests()
         {
             IList<TestDescriptor> lst = new List<TestDescriptor>();
 

--- a/src/Ensconce.NDjango.Tests/MiscellaneousTags.cs
+++ b/src/Ensconce.NDjango.Tests/MiscellaneousTags.cs
@@ -8,13 +8,13 @@ namespace Ensconce.NDjango.Tests
 {
     public partial class TestsRunner
     {
-        [Test, TestCaseSource("GetMiscellaneousTagsTests")]
+        [Test, TestCaseSource(nameof(GetMiscellaneousTagsTests))]
         public void MiscellaneousTags(TestDescriptor test)
         {
             test.Run(manager);
         }
 
-        public static IList<TestDescriptor> GetMiscellaneousTagsTests()
+        private static IList<TestDescriptor> GetMiscellaneousTagsTests()
         {
             IList<TestDescriptor> lst = new List<TestDescriptor>();
             // autoescape tag

--- a/src/Ensconce.NDjango.Tests/ReproducedIssues.cs
+++ b/src/Ensconce.NDjango.Tests/ReproducedIssues.cs
@@ -7,7 +7,7 @@ namespace Ensconce.NDjango.Tests
     public partial class TestsRunner
     {
         //       [Test, TestCaseSource("GetReproducedIssues")]
-        public void ReproducedIssues(TestDescriptor test)
+        private void ReproducedIssues(TestDescriptor test)
         {
             test.Run(manager);
         }
@@ -36,7 +36,7 @@ namespace Ensconce.NDjango.Tests
             return retList;
         }
 
-        public static IList<TestDescriptor> GetReproducedIssues()
+        private static IList<TestDescriptor> GetReproducedIssues()
         {
             IList<TestDescriptor> lst = new List<TestDescriptor>();
 

--- a/src/Ensconce.NDjango.Tests/TestDescriptor.cs
+++ b/src/Ensconce.NDjango.Tests/TestDescriptor.cs
@@ -166,7 +166,7 @@ namespace Ensconce.NDjango.Tests
                     Result = resultGetter();
                 }
 
-                Assert.AreEqual(Result[0], RunTemplate(manager, Template, context), "** Invalid rendering result");
+                Assert.That(RunTemplate(manager, Template, context), Is.EqualTo(Result[0]), "** Invalid rendering result");
                 //if (Vars.Length != 0)
                 //    Assert.AreEqual(Vars, manager.GetTemplateVariables(Template), "** Invalid variable list");
             }
@@ -181,7 +181,7 @@ namespace Ensconce.NDjango.Tests
 
                 if (Result[0] is Type)
                 {
-                    Assert.AreEqual(Result[0], ex.GetType(), "Exception: " + ex.Message);
+                    Assert.That(ex.GetType(), Is.EqualTo(Result[0]), "Exception: " + ex.Message);
                 }
                 else
                 {
@@ -229,14 +229,18 @@ namespace Ensconce.NDjango.Tests
 
             for (var i = 0; i < actualResult.Count; i++)
             {
-                Assert.AreEqual(ResultForDesigner[i].Length, actualResult[i].Length, "Invalid Length");
-                Assert.AreEqual(ResultForDesigner[i].Position, actualResult[i].Position, "Invalid Position");
-                Assert.AreEqual(ResultForDesigner[i].ErrorMessage, actualResult[i].ErrorMessage, "Invalid ErrorMessage");
-                Assert.AreEqual(ResultForDesigner[i].Severity, actualResult[i].Severity, "Invalid Severity");
-                Assert.AreEqual(ResultForDesigner[i].Values.OrderBy(x => x), actualResult[i].Values.OrderBy(x => x), "Invalid Values Array " + i);
+                var result = actualResult[i];
+                Assert.Multiple(() =>
+                {
+                    Assert.That(result.Length, Is.EqualTo(ResultForDesigner[i].Length), "Invalid Length");
+                    Assert.That(result.Position, Is.EqualTo(ResultForDesigner[i].Position), "Invalid Position");
+                    Assert.That(result.ErrorMessage, Is.EqualTo(ResultForDesigner[i].ErrorMessage), "Invalid ErrorMessage");
+                    Assert.That(result.Severity, Is.EqualTo(ResultForDesigner[i].Severity), "Invalid Severity");
+                    Assert.That(result.Values.OrderBy(x => x), Is.EqualTo(ResultForDesigner[i].Values.OrderBy(x => x)), "Invalid Values Array " + i);
+                });
             }
 
-            Assert.AreEqual(ResultForDesigner.Count(), actualResult.Count);
+            Assert.That(actualResult, Has.Count.EqualTo(ResultForDesigner.Count));
         }
 
         private static List<string> GetModelValues(TypeResolver.IDjangoType model, int recursionDepth)

--- a/src/Ensconce.NDjango.Tests/TestsRunner.cs
+++ b/src/Ensconce.NDjango.Tests/TestsRunner.cs
@@ -150,7 +150,7 @@ namespace Ensconce.NDjango.Tests
         /// </summary>
         /// <param name="test"></param>
         //[Test, TestCaseSource("smart_split_tests")]
-        public void TestSmartSplit(StringTest test)
+        private void TestSmartSplit(StringTest test)
         {
             Regex r = new Regex(@"(""(?:[^""\\]*(?:\\.[^""\\]*)*)""|'(?:[^'\\]*(?:\\.[^'\\]*)*)'|[^\s]+)", RegexOptions.Compiled);
             MatchCollection m = r.Matches(@"'\'funky\' style'");
@@ -173,7 +173,7 @@ namespace Ensconce.NDjango.Tests
             //         Assert.AreEqual(to_string_array(of_array(test.expected)), to_string_array(OutputHandling.smart_split(test.provided)));
         }
 
-        public IEnumerable<StringTest> smart_split_tests()
+        private IEnumerable<StringTest> smart_split_tests()
         {
             System.Collections.Generic.List<StringTest> result = new System.Collections.Generic.List<StringTest>();
             result.Add(new StringTest("smart split-01",
@@ -200,7 +200,7 @@ namespace Ensconce.NDjango.Tests
         }
 
         //[Test, TestCaseSource("split_token_tests")]
-        public void TestSplitContent(StringTest test)
+        private void TestSplitContent(StringTest test)
         {
             Func<string[], FSStringList> of_array = (array) => ListModule.OfArray<string>(array);
 
@@ -220,7 +220,7 @@ namespace Ensconce.NDjango.Tests
             //Assert.AreEqual(to_string_array(of_array(test.expected)), to_string_array(OutputHandling.split_token_contents(test.provided)));
         }
 
-        public IEnumerable<StringTest> split_token_tests()
+        private IEnumerable<StringTest> split_token_tests()
         {
             System.Collections.Generic.List<StringTest> result = new System.Collections.Generic.List<StringTest>();
             result.Add(new StringTest("split token-01",

--- a/src/Ensconce.ReportingServices.Tests/Ensconce.ReportingServices.Tests.csproj
+++ b/src/Ensconce.ReportingServices.Tests/Ensconce.ReportingServices.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Description>Tests For Ensconce.ReportingServices</Description>
     <Company>15below</Company>
     <Product>Ensconce</Product>

--- a/src/Ensconce.Update.Tests/Ensconce.Update.Tests.csproj
+++ b/src/Ensconce.Update.Tests/Ensconce.Update.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Description>Tests For Ensconce.Update</Description>
     <Company>15below</Company>
     <Product>Ensconce</Product>


### PR DESCRIPTION
Amended regex that parses filters to allow for whitespace before the argument

Added NUnit analyser into NDJango tests and applied recommendations

Also bumped up all the test projects to net 8.0, as 6.0 is EOL