### PR TITLE
Ignore Octopus variables that are too large for environment variable

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -6,7 +6,7 @@ using System.Text.RegularExpressions;
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Release");
 
-var baseVersion = "1.29.1";
+var baseVersion = "1.29.2";
 var subVersion = "";
 var subVersionNumber = "";
 var isMasterOrDevelop = false;

--- a/src/Scripts/deployHelp.ps1
+++ b/src/Scripts/deployHelp.ps1
@@ -26,7 +26,7 @@ if (Test-Path variable:\OctopusParameters)
 {
     foreach($kp in $OctopusParameters.GetEnumerator())
     {
-        if (!($kp.Key.Contains("Octopus.Step[")) -and !($kp.Key.Contains("Octopus.Action[")) -and !($kp.Key.Contains("Octopus.Only")) -and !($kp.Key.StartsWith("env:")))
+        if (!($kp.Key.Contains("Octopus.Step[")) -and !($kp.Key.Contains("Octopus.Action[")) -and !($kp.Key.Contains("Octopus.Only")) -and !($kp.Key.StartsWith("env:")) -and ($kp.Value.Length -lt 20000))
         {
             Set-Content ("env:\" + $kp.Key.replace("[","-").replace("]","")) ($kp.Value) -Force
         }


### PR DESCRIPTION
Ignore Octopus variables that are too large for environment variable. The deploy script fails if these variables are being added as an environment variable.